### PR TITLE
바뀐 헤더, 메인페이지 스케줄 디자인 반영하기

### DIFF
--- a/apps/user/src/components/common/Header/Header.tsx
+++ b/apps/user/src/components/common/Header/Header.tsx
@@ -84,9 +84,8 @@ const Header = () => {
 export default Header;
 
 const StyledHeader = styled.div`
-    ${flex({ flexDirection: 'column', alignItems: 'center', justifyContent: 'center' })}
     max-width: 1448px;
-    height: 126px;
+    height: 118px;
     background-color: ${color.white};
     margin: 0 auto;
     padding: 0px 100px;

--- a/apps/user/src/components/main/Schedule/Schedule.tsx
+++ b/apps/user/src/components/main/Schedule/Schedule.tsx
@@ -46,7 +46,7 @@ export default Schedule;
 
 const StyledSchedule = styled.div`
     ${flex({ flexDirection: 'column' })}
-    gap: 10px;
+    gap: 24px;
     width: 492px;
     height: 100%;
     padding: 40px 32px;

--- a/apps/user/src/components/main/Schedule/ScheduleItem/ScheduleItem.tsx
+++ b/apps/user/src/components/main/Schedule/ScheduleItem/ScheduleItem.tsx
@@ -26,7 +26,7 @@ export default ScheduleItem;
 
 const StyledScheduleItem = styled.div`
     ${flex({ flexDirection: 'column' })}
-    gap: 3px;
+    gap: 10px;
     height: 58px;
     width: 100%;
 `;


### PR DESCRIPTION
## 📄 Summary

> 바뀐 헤더, 메인페이지 스케줄의 디자인을 반영했습니다.

헤더의 높이를 126px -> 118px로 바꿨고

<img width="1189" alt="스크린샷 2023-08-27 오전 12 03 11" src="https://github.com/Bamdoliro/marururu/assets/102217839/358821bd-3349-4e36-9f18-47e34041fb9e">


스케줄의 gap 속성의 값을 수정했습니다.

<img width="427" alt="스크린샷 2023-08-27 오전 12 02 58" src="https://github.com/Bamdoliro/marururu/assets/102217839/32d39ae6-9350-41af-be5c-16122c49eb15">


<br>

## 🔨 Tasks

-

<br>

## 🙋🏻 More
