### PR TITLE
feat(admin): 상세조회&제출서류 조회 기능

### DIFF
--- a/apps/admin/src/app/form.hooks.ts
+++ b/apps/admin/src/app/form.hooks.ts
@@ -1,8 +1,9 @@
-import { useEditSecondRoundResultMutation } from '@/services/form/mutations';
-import { useDownloadFormUrlQuery } from '@/services/form/queries';
+import {
+  useEditSecondRoundResultMutation,
+  usePrintFormUrlMutation,
+} from '@/services/form/mutations';
 import { useFormToPrintValueStore } from '@/store/form/formToPrint';
 import { useSecondRoundResultValueStore } from '@/store/form/secondRoundResult';
-import { useEffect } from 'react';
 
 export const useSecondRoundResultEditAction = () => {
   const secondRoundResult = useSecondRoundResultValueStore();
@@ -24,33 +25,19 @@ export const useSecondRoundResultEditAction = () => {
   return { handleSecondRoundResultEditCompleteButtonClick };
 };
 
-export const useDownloadFormURLAction = () => {
+export const usePrintFormURLAction = () => {
   const formToPrint = useFormToPrintValueStore();
   const formIdList = Object.entries(formToPrint).reduce(
     (acc: number[], [formId, isSelected]) =>
       isSelected ? [...acc, Number(formId)] : acc,
     []
   );
-
-  const { data: formListData, refetch, status } = useDownloadFormUrlQuery(formIdList);
-
-  useEffect(() => {
-    if (formListData && status === 'success') {
-      formListData.forEach((form) => {
-        const link = document.createElement('a');
-        link.href = form.formUrl;
-        link.target = '_blank';
-        link.download = `${form.examinationNumber}.pdf`;
-        document.body.appendChild(link);
-        link.click();
-        link.remove();
-      });
-    }
-  }, [formListData, status]);
-
-  const handleDownloadFormUrlButtonClick = () => {
-    refetch();
+  const { printFormUrl } = usePrintFormUrlMutation();
+  const handlePrintFormUrlButtonClick = () => {
+    const check = window.open('');
+    check?.close();
+    printFormUrl(formIdList);
   };
 
-  return { handleDownloadFormUrlButtonClick };
+  return { handlePrintFormUrlButtonClick };
 };

--- a/apps/admin/src/app/form.hooks.ts
+++ b/apps/admin/src/app/form.hooks.ts
@@ -39,6 +39,7 @@ export const useDownloadFormURLAction = () => {
       formListData.forEach((form) => {
         const link = document.createElement('a');
         link.href = form.formUrl;
+        link.target = '_blank';
         link.download = `${form.examinationNumber}.pdf`;
         document.body.appendChild(link);
         link.click();

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -25,7 +25,7 @@ import { Button, Column, Row, SearchInput, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import { useOverlay } from '@toss/use-overlay';
 import { styled } from 'styled-components';
-import { useDownloadFormURLAction, useSecondRoundResultEditAction } from './form.hooks';
+import { usePrintFormURLAction, useSecondRoundResultEditAction } from './form.hooks';
 
 if (process.env.NODE_ENV === 'development') {
   initMockAPI();
@@ -76,7 +76,7 @@ const MainPage = () => {
     setFormToPrint({});
   };
 
-  const { handleDownloadFormUrlButtonClick } = useDownloadFormURLAction();
+  const { handlePrintFormUrlButtonClick } = usePrintFormURLAction();
 
   return (
     <AppLayout>
@@ -128,7 +128,7 @@ const MainPage = () => {
                   >
                     취소
                   </Button>
-                  <Button size="SMALL" onClick={handleDownloadFormUrlButtonClick}>
+                  <Button size="SMALL" onClick={handlePrintFormUrlButtonClick}>
                     출력하기
                   </Button>
                 </Row>

--- a/apps/admin/src/components/form/FormDetailContent/FormStatus/FormStatus.hooks.ts
+++ b/apps/admin/src/components/form/FormDetailContent/FormStatus/FormStatus.hooks.ts
@@ -1,11 +1,11 @@
-import { useCheckFormUrlMutation } from '@/services/form/queries';
+import { useCheckFormUrlMutation } from '@/services/form/mutations';
 
 export const useCheckFormStatusURLAction = () => {
-  const { mutate: fetchFormUrls, isLoading } = useCheckFormUrlMutation();
+  const { checkFormUrl } = useCheckFormUrlMutation();
 
   const handleCheckFormStatusUrlButtonClick = (id: number) => {
-    fetchFormUrls([id]);
+    checkFormUrl(id);
   };
 
-  return { handleCheckFormStatusUrlButtonClick, isLoading };
+  return { handleCheckFormStatusUrlButtonClick };
 };

--- a/apps/admin/src/components/form/FormDetailContent/FormStatus/FormStatus.hooks.ts
+++ b/apps/admin/src/components/form/FormDetailContent/FormStatus/FormStatus.hooks.ts
@@ -1,0 +1,11 @@
+import { useCheckFormUrlMutation } from '@/services/form/queries';
+
+export const useCheckFormStatusURLAction = () => {
+  const { mutate: fetchFormUrls, isLoading } = useCheckFormUrlMutation();
+
+  const handleCheckFormStatusUrlButtonClick = (id: number) => {
+    fetchFormUrls([id]);
+  };
+
+  return { handleCheckFormStatusUrlButtonClick, isLoading };
+};

--- a/apps/admin/src/components/form/FormDetailContent/FormStatus/FormStatus.tsx
+++ b/apps/admin/src/components/form/FormDetailContent/FormStatus/FormStatus.tsx
@@ -5,6 +5,7 @@ import { flex } from '@maru/utils';
 import { useOverlay } from '@toss/use-overlay';
 import styled from 'styled-components';
 import FinalScoreConfirm from '../ChangeFinalScoreModal/ChangeFinalScoreModal';
+import { useCheckFormStatusURLAction } from './FormStatus.hooks';
 
 interface Props {
   id: number;
@@ -38,6 +39,8 @@ const FormStatus = ({ id }: Props) => {
       <FinalScoreConfirm id={id} isOpen={isOpen} onClose={close} />
     ));
   };
+
+  const { handleCheckFormStatusUrlButtonClick } = useCheckFormStatusURLAction();
 
   return (
     <StyledFormStatus>
@@ -98,7 +101,11 @@ const FormStatus = ({ id }: Props) => {
         <Button size="SMALL" onClick={openFinalScoreConfirm}>
           최종 접수 상태 변경하기
         </Button>
-        <Button size="SMALL" styleType="SECONDARY">
+        <Button
+          size="SMALL"
+          styleType="SECONDARY"
+          onClick={() => handleCheckFormStatusUrlButtonClick(id)}
+        >
           제출 서류 조회하기
         </Button>
       </Column>

--- a/apps/admin/src/services/form/mutations.ts
+++ b/apps/admin/src/services/form/mutations.ts
@@ -94,10 +94,14 @@ export const usePrintFormUrlMutation = () => {
   const { mutate: printFormUrl, ...restMutation } = useMutation({
     mutationFn: (formIdList: number[]) => getFormUrl(formIdList),
     onSuccess: (formURL) => {
+      let hasShownAlert = false;
       formURL.dataList.forEach((formURL) => {
         const link = window.open(formURL.formUrl);
         if (!link || link.closed || typeof link.closed == 'undefined') {
-          alert('팝업 및 리디렉션을 허용해주세요');
+          if (!hasShownAlert) {
+            alert('팝업 및 리디렉션을 허용해주세요');
+            hasShownAlert = true;
+          }
         }
       });
     },

--- a/apps/admin/src/services/form/mutations.ts
+++ b/apps/admin/src/services/form/mutations.ts
@@ -4,7 +4,12 @@ import { useSetSecondRoundResultStore } from '@/store/form/secondRoundResult';
 import type { PatchSecondRoundResultReq } from '@/types/form/remote';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
-import { patchFinalScore, patchSecondRoundResult, patchSecondScoreFormat } from './api';
+import {
+  patchFinalScore,
+  patchSecondRoundResult,
+  patchSecondScoreFormat,
+  getFormUrl,
+} from './api';
 import { useFormListQuery } from './queries';
 
 import type { ApprovalStatus } from '@/types/form/client';
@@ -67,4 +72,37 @@ export const useChangeFinalScoreStatusMutation = (
     onError: handleError,
   });
   return { changeFinalScoreStatus, ...restMutation };
+};
+
+export const useCheckFormUrlMutation = () => {
+  const { handleError } = useApiError();
+  const { mutate: checkFormUrl, ...restMutation } = useMutation({
+    mutationFn: (formId: number) => getFormUrl([formId]),
+    onSuccess: (formURL) => {
+      if (formURL.dataList.length > 0) {
+        window.open(formURL.dataList[0].formUrl);
+      }
+    },
+    onError: handleError,
+  });
+
+  return { checkFormUrl, ...restMutation };
+};
+
+export const usePrintFormUrlMutation = () => {
+  const { handleError } = useApiError();
+  const { mutate: printFormUrl, ...restMutation } = useMutation({
+    mutationFn: (formIdList: number[]) => getFormUrl(formIdList),
+    onSuccess: (formURL) => {
+      formURL.dataList.forEach((formURL) => {
+        const link = window.open(formURL.formUrl);
+        if (!link || link.closed || typeof link.closed == 'undefined') {
+          alert('팝업 및 리디렉션을 허용해주세요');
+        }
+      });
+    },
+    onError: handleError,
+  });
+
+  return { printFormUrl, ...restMutation };
 };

--- a/apps/admin/src/services/form/queries.ts
+++ b/apps/admin/src/services/form/queries.ts
@@ -1,7 +1,7 @@
 import { KEY } from '@/constants/common/constant';
 import { useFormListTypeValueStore } from '@/store/form/type';
 import { ExportExcelType } from '@/types/form/client';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
   getExportExcel,
   getFormDetail,
@@ -50,26 +50,4 @@ export const useFormDetailQuery = (id: number) => {
   });
 
   return { data: data?.data, ...restQuery };
-};
-
-export const useDownloadFormUrlQuery = (formIdList: number[]) => {
-  const { data, ...restQuery } = useQuery({
-    queryKey: [KEY.FORM_URL],
-    queryFn: () => getFormUrl(formIdList),
-    enabled: false,
-  });
-
-  return { data: data?.dataList, ...restQuery };
-};
-
-export const useCheckFormUrlMutation = () => {
-  const mutation = useMutation((formIdList: number[]) => getFormUrl(formIdList), {
-    onSuccess: (data) => {
-      data.dataList.forEach((form) => {
-        window.open(form.formUrl);
-      });
-    },
-  });
-
-  return mutation;
 };

--- a/apps/admin/src/services/form/queries.ts
+++ b/apps/admin/src/services/form/queries.ts
@@ -1,7 +1,7 @@
 import { KEY } from '@/constants/common/constant';
 import { useFormListTypeValueStore } from '@/store/form/type';
-import type { ExportExcelType } from '@/types/form/client';
-import { useQuery } from '@tanstack/react-query';
+import { ExportExcelType } from '@/types/form/client';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import {
   getExportExcel,
   getFormDetail,
@@ -60,4 +60,16 @@ export const useDownloadFormUrlQuery = (formIdList: number[]) => {
   });
 
   return { data: data?.dataList, ...restQuery };
+};
+
+export const useCheckFormUrlMutation = () => {
+  const mutation = useMutation((formIdList: number[]) => getFormUrl(formIdList), {
+    onSuccess: (data) => {
+      data.dataList.forEach((form) => {
+        window.open(form.formUrl);
+      });
+    },
+  });
+
+  return mutation;
 };

--- a/apps/admin/src/services/form/queries.ts
+++ b/apps/admin/src/services/form/queries.ts
@@ -1,14 +1,8 @@
 import { KEY } from '@/constants/common/constant';
 import { useFormListTypeValueStore } from '@/store/form/type';
-import { ExportExcelType } from '@/types/form/client';
 import { useQuery } from '@tanstack/react-query';
-import {
-  getExportExcel,
-  getFormDetail,
-  getFormList,
-  getFormUrl,
-  getSecondScoreFormat,
-} from './api';
+import { getExportExcel, getFormDetail, getFormList, getSecondScoreFormat } from './api';
+import type { ExportExcelType } from '@/types/form/client';
 
 export const useFormListQuery = () => {
   const formListType = useFormListTypeValueStore();


### PR DESCRIPTION
## 📄 Summary

> 어드민 원서관리 페이지의 상세조회&제출서류조회 원서 출력 기능을 추가 했습니다.
> 어드민 원서관리 페이지의 추가기능 원서 출력하기 기능에서 팝업이 차단되어있을 시에 팝업 차단 해제 유도 코드를 개발 했습니다.

<br>

## 🔨 Tasks

- 어드민 상세조회&제출서류조회 원서 출력 기능 개발
- 어드민 원서 출력하기 팝업 차단 해제 유도 기능 개발

<br>

## 🙋🏻 More
