### PR TITLE
feat(user): 입학설명회 일정 페이지 개발

### DIFF
--- a/apps/user/src/app/fair/page.tsx
+++ b/apps/user/src/app/fair/page.tsx
@@ -1,17 +1,76 @@
 'use client';
 
+import React, { useState, useEffect } from 'react';
 import { AppLayout } from '@/layouts';
 import { color } from '@maru/design-token';
-import { styled } from 'styled-components';
-import { Text } from '@maru/ui';
+import { Column, Text } from '@maru/ui';
+import styled from 'styled-components';
+import { Suspense } from '@suspensive/react';
+import { ApplyingList, ClosedList, Header } from '@/components/fair';
 
 const FairPage = () => {
+  const [status, setStatus] = useState('진행 중인 신청');
+
+  useEffect(() => {
+    const savedStatus = localStorage.getItem('selectedTab');
+    if (savedStatus) {
+      setStatus(savedStatus);
+    }
+  }, []);
+
+  const handleTabClick = (name: string) => {
+    setStatus(name);
+    localStorage.setItem('selectedTab', name);
+  };
+
+  const renderContent = () => {
+    if (status === '진행 중인 신청') {
+      return (
+        <>
+          <Column gap={16}>
+            <Text fontType="H3" color={color.gray900}>
+              학생
+            </Text>
+            <ApplyingList fairType="STUDENT_AND_PARENT" />
+          </Column>
+          <Separator />
+          <Column gap={16}>
+            <Text fontType="H3" color={color.gray900}>
+              교사
+            </Text>
+            <ApplyingList fairType="TEACHER" />
+          </Column>
+        </>
+      );
+    } else if (status === '마감된 신청') {
+      return (
+        <>
+          <Column gap={16}>
+            <Text fontType="H3" color={color.gray900}>
+              학생
+            </Text>
+            <ClosedList fairType="STUDENT_AND_PARENT" />
+          </Column>
+          <Separator />
+          <Column gap={16}>
+            <Text fontType="H3" color={color.gray900}>
+              교사
+            </Text>
+            <ClosedList fairType="TEACHER" />
+          </Column>
+        </>
+      );
+    }
+  };
+
   return (
     <AppLayout header footer>
       <StyledFairPage>
         <Text fontType="H1" color={color.gray900}>
           2024학년도 부산소프트웨어마이스터고등학교 <br /> 입학전형 설명회 참가 신청
         </Text>
+        <Header selectedTab={status} handleTabClick={handleTabClick} />
+        <Suspense.CSROnly>{renderContent()}</Suspense.CSROnly>
       </StyledFairPage>
     </AppLayout>
   );
@@ -26,4 +85,12 @@ const StyledFairPage = styled.div`
   height: 100%;
   margin: 0 auto;
   padding: 82px 204px 240px;
+`;
+
+const Separator = styled.p`
+  border: 1px solid ${color.gray400};
+  margin: 2% 0;
+  width: 800px;
+  margin-top: 56px;
+  margin-bottom: 56px;
 `;

--- a/apps/user/src/app/fair/page.tsx
+++ b/apps/user/src/app/fair/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { AppLayout } from '@/layouts';
+import { color } from '@maru/design-token';
+import { styled } from 'styled-components';
+import { Text } from '@maru/ui';
+
+const FairPage = () => {
+  return (
+    <AppLayout header footer>
+      <StyledFairPage>
+        <Text fontType="H1" color={color.gray900}>
+          2024학년도 부산소프트웨어마이스터고등학교 <br /> 입학전형 설명회 참가 신청
+        </Text>
+      </StyledFairPage>
+    </AppLayout>
+  );
+};
+
+export default FairPage;
+
+const StyledFairPage = styled.div`
+  position: relative;
+  width: 100%;
+  max-width: 1240px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 82px 204px 240px;
+`;

--- a/apps/user/src/app/fair/page.tsx
+++ b/apps/user/src/app/fair/page.tsx
@@ -90,7 +90,7 @@ const StyledFairPage = styled.div`
 const Separator = styled.p`
   border: 1px solid ${color.gray400};
   margin: 2% 0;
-  width: 800px;
+  width: 830px;
   margin-top: 56px;
   margin-bottom: 56px;
 `;

--- a/apps/user/src/components/fair/FairList/ApplyingItem/ApplyingItem.tsx
+++ b/apps/user/src/components/fair/FairList/ApplyingItem/ApplyingItem.tsx
@@ -1,0 +1,69 @@
+import { styled } from 'styled-components';
+import { flex } from '@maru/utils';
+import { color } from '@maru/design-token';
+import { Row, Text } from '@maru/ui';
+import { formatApplicationDate, formatStartDate, formatStatus } from '@/utils';
+
+interface Props {
+  place: string;
+  applicationStartDate: string;
+  applicationEndDate: string;
+  start: string;
+  status: string;
+}
+
+const ApplyingItem = ({
+  place,
+  applicationEndDate,
+  applicationStartDate,
+  start,
+  status,
+}: Props) => {
+  return (
+    <StyledBox>
+      <Row gap={30} alignItems="center">
+        <Text fontType="H3" color={color.gray900}>
+          {formatStartDate(start)}
+        </Text>
+        <StyledStatusBox>
+          <Text fontType="code" color={color.maruDefault}>
+            {formatStatus(status)}
+          </Text>
+        </StyledStatusBox>
+      </Row>
+      <Text fontType="p2" color={color.gray500}>
+        장소: {place}
+        <br />
+        신청 기한: {formatApplicationDate(applicationStartDate)} ~{' '}
+        {formatApplicationDate(applicationEndDate)}
+      </Text>
+    </StyledBox>
+  );
+};
+
+export default ApplyingItem;
+
+const StyledBox = styled.div`
+  ${flex({ flexDirection: 'column', justifyContent: 'space-between' })}
+  width: 400px;
+  height: 180px;
+  padding: 28px 32px;
+  background-color: ${color.white};
+  border: 1px solid ${color.gray200};
+  border-radius: 12px;
+  cursor: pointer;
+  margin-bottom: 16px;
+  margin-right: 16px;
+`;
+
+const StyledStatusBox = styled.div`
+  width: 80px;
+  height: 32px;
+  border-radius: 16px;
+  border: 1px solid ${color.maruDefault};
+  background-color: rgba(37, 124, 255, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+`;

--- a/apps/user/src/components/fair/FairList/ApplyingList.tsx
+++ b/apps/user/src/components/fair/FairList/ApplyingList.tsx
@@ -12,12 +12,7 @@ const ApplyingList = ({ fairType }: Props) => {
   return fairListData ? (
     <StyledFairList itemCount={fairListData.length}>
       {fairListData
-        .filter(
-          ({ status }) =>
-            status === 'APPLICATION_IN_PROGRESS' ||
-            status === 'APPLICATION_NOT_STARTED' ||
-            status === null
-        )
+        .filter(({ status }) => status === 'APPLICATION_IN_PROGRESS' || status === null)
         .map(
           ({ start, place, status, applicationStartDate, applicationEndDate }, index) => (
             <ApplyingItem

--- a/apps/user/src/components/fair/FairList/ApplyingList.tsx
+++ b/apps/user/src/components/fair/FairList/ApplyingList.tsx
@@ -10,7 +10,10 @@ const ApplyingList = ({ fairType }: Props) => {
   const { data: fairListData } = useFairListQuery(fairType);
 
   return fairListData ? (
-    <StyledFairList itemCount={fairListData.length}>
+    <StyledFairList
+      itemCount={fairListData.length}
+      onClick={() => alert('누르면 구글폼으로')}
+    >
       {fairListData
         .filter(({ status }) => status === 'APPLICATION_IN_PROGRESS' || status === null)
         .map(

--- a/apps/user/src/components/fair/FairList/ApplyingList.tsx
+++ b/apps/user/src/components/fair/FairList/ApplyingList.tsx
@@ -1,0 +1,37 @@
+import { useFairListQuery } from '@/services/fair/queries';
+import ApplyingItem from './ApplyingItem/ApplyingItem';
+import { styled } from 'styled-components';
+import { flex } from '@maru/utils';
+
+interface Props {
+  fairType: string;
+}
+
+const ApplyingList = ({ fairType }: Props) => {
+  const { data: fairListData } = useFairListQuery(fairType);
+
+  return fairListData ? (
+    <StyledFairList>
+      {fairListData.map(
+        ({ start, place, status, applicationStartDate, applicationEndDate }, index) => (
+          <ApplyingItem
+            key={`applying ${index}`}
+            place={place}
+            applicationStartDate={applicationStartDate}
+            applicationEndDate={applicationEndDate}
+            start={start}
+            status={status}
+          />
+        )
+      )}
+    </StyledFairList>
+  ) : null;
+};
+
+export default ApplyingList;
+
+const StyledFairList = styled.div`
+  position: relative;
+  ${flex({ flexDirection: 'column' })}
+  width: 100%;
+`;

--- a/apps/user/src/components/fair/FairList/ApplyingList.tsx
+++ b/apps/user/src/components/fair/FairList/ApplyingList.tsx
@@ -1,7 +1,6 @@
 import { useFairListQuery } from '@/services/fair/queries';
 import ApplyingItem from './ApplyingItem/ApplyingItem';
 import { styled } from 'styled-components';
-import { flex } from '@maru/utils';
 
 interface Props {
   fairType: string;
@@ -11,27 +10,39 @@ const ApplyingList = ({ fairType }: Props) => {
   const { data: fairListData } = useFairListQuery(fairType);
 
   return fairListData ? (
-    <StyledFairList>
-      {fairListData.map(
-        ({ start, place, status, applicationStartDate, applicationEndDate }, index) => (
-          <ApplyingItem
-            key={`applying ${index}`}
-            place={place}
-            applicationStartDate={applicationStartDate}
-            applicationEndDate={applicationEndDate}
-            start={start}
-            status={status}
-          />
+    <StyledFairList itemCount={fairListData.length}>
+      {fairListData
+        .filter(
+          ({ status }) =>
+            status === 'APPLICATION_IN_PROGRESS' ||
+            status === 'APPLICATION_NOT_STARTED' ||
+            status === null
         )
-      )}
+        .map(
+          ({ start, place, status, applicationStartDate, applicationEndDate }, index) => (
+            <ApplyingItem
+              key={`applying ${index}`}
+              place={place}
+              applicationStartDate={applicationStartDate}
+              applicationEndDate={applicationEndDate}
+              start={start}
+              status={status}
+            />
+          )
+        )}
     </StyledFairList>
   ) : null;
 };
 
 export default ApplyingList;
 
-const StyledFairList = styled.div`
-  position: relative;
-  ${flex({ flexDirection: 'column' })}
-  width: 100%;
+const StyledFairList = styled.div<{ itemCount: number }>`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  gap: 16px;
+
+  @media (min-width: 800px) {
+    grid-template-columns: ${({ itemCount }) =>
+      itemCount <= 2 ? 'repeat(2, 1fr)' : 'repeat(2, 1fr)'};
+  }
 `;

--- a/apps/user/src/components/fair/FairList/ClosedItem/ClosedItem.tsx
+++ b/apps/user/src/components/fair/FairList/ClosedItem/ClosedItem.tsx
@@ -1,0 +1,69 @@
+import { styled } from 'styled-components';
+import { flex } from '@maru/utils';
+import { color } from '@maru/design-token';
+import { Row, Text } from '@maru/ui';
+import { formatApplicationDate, formatStartDate, formatStatus } from '@/utils';
+
+interface Props {
+  place: string;
+  applicationStartDate: string;
+  applicationEndDate: string;
+  start: string;
+  status: string;
+}
+
+const ClosedItem = ({
+  place,
+  applicationEndDate,
+  applicationStartDate,
+  start,
+  status,
+}: Props) => {
+  return (
+    <StyledBox>
+      <Row gap={30} alignItems="center">
+        <Text fontType="H3" color={color.gray900}>
+          {formatStartDate(start)}
+        </Text>
+        <StyledStatusBox>
+          <Text fontType="code" color={color.red}>
+            {formatStatus(status)}
+          </Text>
+        </StyledStatusBox>
+      </Row>
+      <Text fontType="p2" color={color.gray500}>
+        장소: {place}
+        <br />
+        신청 기한: {formatApplicationDate(applicationStartDate)} ~{' '}
+        {formatApplicationDate(applicationEndDate)}
+      </Text>
+    </StyledBox>
+  );
+};
+
+export default ClosedItem;
+
+const StyledBox = styled.div`
+  ${flex({ flexDirection: 'column', justifyContent: 'space-between' })}
+  width: 400px;
+  height: 180px;
+  padding: 28px 32px;
+  background-color: ${color.white};
+  border: 1px solid ${color.gray200};
+  border-radius: 12px;
+  cursor: pointer;
+  margin-bottom: 16px;
+  margin-right: 16px;
+`;
+
+const StyledStatusBox = styled.div`
+  width: 80px;
+  height: 32px;
+  border-radius: 16px;
+  border: 1px solid ${color.red};
+  background-color: rgba(244, 67, 54, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+`;

--- a/apps/user/src/components/fair/FairList/ClosedList.tsx
+++ b/apps/user/src/components/fair/FairList/ClosedList.tsx
@@ -1,7 +1,6 @@
 import { useFairListQuery } from '@/services/fair/queries';
 import ClosedItem from './ClosedItem/ClosedItem';
 import { styled } from 'styled-components';
-import { flex } from '@maru/utils';
 
 interface Props {
   fairType: string;
@@ -11,27 +10,39 @@ const ClosedList = ({ fairType }: Props) => {
   const { data: fairListData } = useFairListQuery(fairType);
 
   return fairListData ? (
-    <StyledFairList>
-      {fairListData.map(
-        ({ start, place, status, applicationStartDate, applicationEndDate }, index) => (
-          <ClosedItem
-            key={`applying ${index}`}
-            place={place}
-            applicationStartDate={applicationStartDate}
-            applicationEndDate={applicationEndDate}
-            start={start}
-            status={status}
-          />
+    <StyledFairList itemCount={fairListData.length}>
+      {fairListData
+        .filter(
+          ({ status }) =>
+            status === 'APPLICATION_CLOSED' ||
+            status === 'APPLICATION_EARLY_CLOSED' ||
+            status === 'CLOSED'
         )
-      )}
+        .map(
+          ({ start, place, status, applicationStartDate, applicationEndDate }, index) => (
+            <ClosedItem
+              key={`closed ${index}`}
+              place={place}
+              applicationStartDate={applicationStartDate}
+              applicationEndDate={applicationEndDate}
+              start={start}
+              status={status}
+            />
+          )
+        )}
     </StyledFairList>
   ) : null;
 };
 
 export default ClosedList;
 
-const StyledFairList = styled.div`
-  position: relative;
-  ${flex({ flexDirection: 'column' })}
-  width: 100%;
+const StyledFairList = styled.div<{ itemCount: number }>`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  gap: 16px;
+
+  @media (min-width: 800px) {
+    grid-template-columns: ${({ itemCount }) =>
+      itemCount <= 2 ? 'repeat(2, 1fr)' : 'repeat(2, 1fr)'};
+  }
 `;

--- a/apps/user/src/components/fair/FairList/ClosedList.tsx
+++ b/apps/user/src/components/fair/FairList/ClosedList.tsx
@@ -10,7 +10,10 @@ const ClosedList = ({ fairType }: Props) => {
   const { data: fairListData } = useFairListQuery(fairType);
 
   return fairListData ? (
-    <StyledFairList itemCount={fairListData.length}>
+    <StyledFairList
+      itemCount={fairListData.length}
+      onClick={() => alert('마감되어 신청 불가')}
+    >
       {fairListData
         .filter(
           ({ status }) =>

--- a/apps/user/src/components/fair/FairList/ClosedList.tsx
+++ b/apps/user/src/components/fair/FairList/ClosedList.tsx
@@ -14,9 +14,7 @@ const ClosedList = ({ fairType }: Props) => {
       {fairListData
         .filter(
           ({ status }) =>
-            status === 'APPLICATION_CLOSED' ||
-            status === 'APPLICATION_EARLY_CLOSED' ||
-            status === 'CLOSED'
+            status === 'APPLICATION_CLOSED' || status === 'APPLICATION_EARLY_CLOSED'
         )
         .map(
           ({ start, place, status, applicationStartDate, applicationEndDate }, index) => (

--- a/apps/user/src/components/fair/FairList/ClosedList.tsx
+++ b/apps/user/src/components/fair/FairList/ClosedList.tsx
@@ -1,0 +1,37 @@
+import { useFairListQuery } from '@/services/fair/queries';
+import ClosedItem from './ClosedItem/ClosedItem';
+import { styled } from 'styled-components';
+import { flex } from '@maru/utils';
+
+interface Props {
+  fairType: string;
+}
+
+const ClosedList = ({ fairType }: Props) => {
+  const { data: fairListData } = useFairListQuery(fairType);
+
+  return fairListData ? (
+    <StyledFairList>
+      {fairListData.map(
+        ({ start, place, status, applicationStartDate, applicationEndDate }, index) => (
+          <ClosedItem
+            key={`applying ${index}`}
+            place={place}
+            applicationStartDate={applicationStartDate}
+            applicationEndDate={applicationEndDate}
+            start={start}
+            status={status}
+          />
+        )
+      )}
+    </StyledFairList>
+  ) : null;
+};
+
+export default ClosedList;
+
+const StyledFairList = styled.div`
+  position: relative;
+  ${flex({ flexDirection: 'column' })}
+  width: 100%;
+`;

--- a/apps/user/src/components/fair/Header/header.tsx
+++ b/apps/user/src/components/fair/Header/header.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { color } from '@maru/design-token';
+import { UnderlineButton, Row } from '@maru/ui';
+import styled from 'styled-components';
+
+const NAVIGATION_LIST = [
+  {
+    name: '진행 중인 신청',
+  },
+  {
+    name: '마감된 신청',
+  },
+];
+
+interface Props {
+  selectedTab: string;
+  handleTabClick: (name: string) => void;
+}
+
+const Header: React.FC<Props> = ({ selectedTab, handleTabClick }) => {
+  return (
+    <StyledHeader>
+      <Row alignItems="center" justifyContent="space-between">
+        <Row>
+          {NAVIGATION_LIST.map(({ name }, index) => (
+            <UnderlineButton
+              key={`navigation ${index}`}
+              active={name === selectedTab}
+              onClick={() => handleTabClick(name)}
+            >
+              {name}
+            </UnderlineButton>
+          ))}
+        </Row>
+      </Row>
+    </StyledHeader>
+  );
+};
+
+export default Header;
+
+const StyledHeader = styled.div`
+  width: 100%;
+  background-color: ${color.white};
+  padding-bottom: 36px;
+  padding-top: 36px;
+`;

--- a/apps/user/src/components/fair/index.ts
+++ b/apps/user/src/components/fair/index.ts
@@ -1,0 +1,3 @@
+export { default as Header } from './Header/header';
+export { default as ApplyingList } from './FairList/ApplyingList';
+export { default as ClosedList } from './FairList/ClosedList';

--- a/apps/user/src/components/main/ApplicationBox/ApplicationBox.tsx
+++ b/apps/user/src/components/main/ApplicationBox/ApplicationBox.tsx
@@ -4,12 +4,14 @@ import { Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import styled from 'styled-components';
 import { ROUTES } from '@/constants/common/constant';
+import { useRouter } from 'next/navigation';
 
 const ApplicationBox = () => {
   const day = '7월 8일, 8월 26일, 9월 16일, 10월 4일';
+  const router = useRouter();
 
   return (
-    <StyledApplicationBox onClick={() => ROUTES.FAIR}>
+    <StyledApplicationBox onClick={() => router.push(ROUTES.FAIR)}>
       <Row gap={8} alignItems="center">
         <Text fontType="H3" color={color.gray900}>
           입학전형 설명회 신청

--- a/apps/user/src/components/main/ApplicationBox/ApplicationBox.tsx
+++ b/apps/user/src/components/main/ApplicationBox/ApplicationBox.tsx
@@ -3,12 +3,13 @@ import { color } from '@maru/design-token';
 import { Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import styled from 'styled-components';
+import { ROUTES } from '@/constants/common/constant';
 
 const ApplicationBox = () => {
   const day = '7월 8일, 8월 26일, 9월 16일, 10월 4일';
 
   return (
-    <StyledApplicationBox onClick={() => alert('준비 중입니다.')}>
+    <StyledApplicationBox onClick={() => ROUTES.FAIR}>
       <Row gap={8} alignItems="center">
         <Text fontType="H3" color={color.gray900}>
           입학전형 설명회 신청

--- a/apps/user/src/constants/common/constant.ts
+++ b/apps/user/src/constants/common/constant.ts
@@ -10,6 +10,7 @@ export const KEY = {
   FORM_STATUS: 'useFormStatus',
   FIRST_RESULT: 'useFirstResult',
   FINAL_RESULT: 'useFinalResult',
+  FAIR_LIST: 'useFairQuery',
 } as const;
 
 export const ROUTES = {

--- a/apps/user/src/services/fair/api.ts
+++ b/apps/user/src/services/fair/api.ts
@@ -1,0 +1,7 @@
+import { maru } from '@/apis/instance/instance';
+import type { GetFairListRes } from '@/types/fair/remote';
+
+export const getFairList = async (fairType: string) => {
+  const { data } = await maru.get<GetFairListRes>(`/fair?fairType=${fairType}`);
+  return data;
+};

--- a/apps/user/src/services/fair/api.ts
+++ b/apps/user/src/services/fair/api.ts
@@ -2,6 +2,6 @@ import { maru } from '@/apis/instance/instance';
 import type { GetFairListRes } from '@/types/fair/remote';
 
 export const getFairList = async (fairType: string) => {
-  const { data } = await maru.get<GetFairListRes>(`/fair?fairType=${fairType}`);
+  const { data } = await maru.get<GetFairListRes>(`/fair?type=${fairType}`);
   return data;
 };

--- a/apps/user/src/services/fair/queries.ts
+++ b/apps/user/src/services/fair/queries.ts
@@ -1,0 +1,12 @@
+import { KEY } from '@/constants/common/constant';
+import { useSuspenseQuery } from '@suspensive/react-query';
+import { getFairList } from './api';
+
+export const useFairListQuery = (fairType: string) => {
+  const { data, ...restQuery } = useSuspenseQuery({
+    queryKey: [KEY.FAIR_LIST, fairType] as const,
+    queryFn: () => getFairList(fairType),
+  });
+
+  return { data: data.dataList, ...restQuery };
+};

--- a/apps/user/src/types/fair/client.ts
+++ b/apps/user/src/types/fair/client.ts
@@ -1,0 +1,7 @@
+export interface Fair {
+  start: string;
+  place: string;
+  applicationStartDate: string;
+  applicationEndDate: string;
+  status: string;
+}

--- a/apps/user/src/types/fair/remote.ts
+++ b/apps/user/src/types/fair/remote.ts
@@ -1,0 +1,5 @@
+import type { Fair } from './client';
+
+export interface GetFairListRes {
+  dataList: Fair[];
+}

--- a/apps/user/src/utils/formatApplicationDate.ts
+++ b/apps/user/src/utils/formatApplicationDate.ts
@@ -1,0 +1,11 @@
+const formatApplicationDate = (applicationDate: string) => {
+  const date = new Date(applicationDate);
+
+  const year = date.getFullYear(),
+    month = (date.getMonth() + 1).toString().padStart(2, '0'),
+    day = date.getDate().toString().padStart(2, '0');
+
+  return `${year}.${month}.${day}`;
+};
+
+export default formatApplicationDate;

--- a/apps/user/src/utils/formatStartDate.ts
+++ b/apps/user/src/utils/formatStartDate.ts
@@ -1,0 +1,15 @@
+const formatStartDate = (startDate: string) => {
+  const date = new Date(startDate);
+
+  const month = (date.getMonth() + 1).toString().padStart(2, '0'),
+    day = date.getDate().toString().padStart(2, '0'),
+    hours = date.getHours().toString().padStart(2, '0'),
+    minutes = date.getMinutes().toString().padStart(2, '0');
+
+  const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
+  const dayOfWeek = daysOfWeek[date.getDay()];
+
+  return `${month}월 ${day}일 (${dayOfWeek}) ${hours}:${minutes}`;
+};
+
+export default formatStartDate;

--- a/apps/user/src/utils/formatStatus.ts
+++ b/apps/user/src/utils/formatStatus.ts
@@ -1,9 +1,9 @@
 const statusMap: { [key: string]: string } = {
-  APPLICATION_ENDED: '신청 종료됨',
-  CLOSED: '종료됨',
-  APPLICATION_IN_PROGRESS: '신청 진행 중',
-  APPLICATION_NOT_STARTED: '신청 시작 전',
-  APPLICATION_EARLY_CLOSED: '신청 조기 종료됨',
+  APPLICATION_ENDED: '신청 마감',
+  CLOSED: '종료',
+  APPLICATION_IN_PROGRESS: '진행 중',
+  APPLICATION_NOT_STARTED: '준비 중',
+  APPLICATION_EARLY_CLOSED: '조기 마감',
 };
 
 export const formatStatus = (status: string) => {

--- a/apps/user/src/utils/formatStatus.ts
+++ b/apps/user/src/utils/formatStatus.ts
@@ -1,0 +1,11 @@
+const statusMap: { [key: string]: string } = {
+  APPLICATION_ENDED: '신청 종료됨',
+  CLOSED: '종료됨',
+  APPLICATION_IN_PROGRESS: '신청 진행 중',
+  APPLICATION_NOT_STARTED: '신청 시작 전',
+  APPLICATION_EARLY_CLOSED: '신청 조기 종료됨',
+};
+
+export const formatStatus = (status: string) => {
+  return statusMap[status] || status;
+};

--- a/apps/user/src/utils/index.ts
+++ b/apps/user/src/utils/index.ts
@@ -2,3 +2,6 @@ export { default as getAchivementLevel } from './/getAchivementLevel';
 export { default as formatDate } from './formatDate';
 export { default as formatDay } from './formatDay';
 export { default as updateSlicedSubjectList } from './updateSlicedSubjectList';
+export { default as formatApplicationDate } from './formatApplicationDate';
+export { default as formatStartDate } from './formatStartDate';
+export { formatStatus } from './formatStatus';


### PR DESCRIPTION
## 📄 Summary

> 일정 페에지로 이동하도록 코드 수정
> 일정 데이터 가져오기
> 일정 데이터 가공하기

<br>

## 🔨 Tasks

- 일정상태가 진행 중이거나 진행 전, null이면 진행 중인 신청 탭에 일정상태가 마감이나 조기마감이라면 마감된 신청 탭에 각각 아이템들이 뜨도록 개발했습니다.
- 일정이 2개라면 가로 한줄로 뜨지만 3개 이상이라면 그 밑으로 보이도록 개발했습니다.

<br>

## 🙋🏻 More
추후 백엔드에서 구글폼url을 생성할때 저장하면 이를 불러와서 구글폼으로 이어지도록 개발 예정
(올해는 시간적 문제로 신청은 마루 대신 구글폼으로 받기로 했습니다.)