### PR TITLE
feat(admin): 로그아웃 시 로그인 페이지로 이동 및 유저 리다이렉트 기능 추가

### DIFF
--- a/apps/admin/src/constants/common/constant.ts
+++ b/apps/admin/src/constants/common/constant.ts
@@ -1,4 +1,5 @@
 export const KEY = {
+  LOGIN_CHECK: 'useLoginCheck',
   NOTICE_LIST: 'useNoticeList',
   FORM_LIST: 'useFormList',
   SECOND_SCORE_FORMAT: 'useSecondScoreFormat',

--- a/apps/admin/src/hocs/withAuth.tsx
+++ b/apps/admin/src/hocs/withAuth.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import { Storage } from '@/apis/storage/storage';
+import { useLoginCheckQuery } from '@/services/auth/queries';
 import { TOKEN, ROUTES } from '@/constants/common/constant';
 import { useRouter } from 'next/navigation';
 
 const withAuth = (Component: React.ComponentType) => {
   const WrappedComponent = () => {
+    const { data } = useLoginCheckQuery();
     const router = useRouter();
     const [isMounted, setIsMounted] = useState(false);
     const hasAccessToken = Boolean(Storage.getItem(TOKEN.ACCESS));
+    const LOGIN_TYPE = data?.data.authority;
 
     useEffect(() => {
       if (typeof window !== 'undefined') {
@@ -16,7 +19,11 @@ const withAuth = (Component: React.ComponentType) => {
     }, []);
 
     useEffect(() => {
-      if (isMounted && !hasAccessToken) {
+      if (isMounted && LOGIN_TYPE === 'USER') {
+        alert('잘못된 접근 입니다.');
+        router.replace(ROUTES.LOGIN);
+        localStorage.clear();
+      } else if (isMounted && !hasAccessToken) {
         alert('이용하시려면 로그인이 필요합니다.');
         router.replace(ROUTES.LOGIN);
       }

--- a/apps/admin/src/services/auth/api.ts
+++ b/apps/admin/src/services/auth/api.ts
@@ -1,6 +1,6 @@
 import { maru } from '@/apis/instance/instance';
 import { authorization } from '@/apis/token';
-import type { PostLoginAuthReq } from '@/types/auth/remote';
+import type { PostLoginAuthReq, GetCheckLoginRes } from '@/types/auth/remote';
 
 export const postLoginAdmin = async ({ phoneNumber, password }: PostLoginAuthReq) => {
   const { data } = await maru.post('/auth', { phoneNumber, password });
@@ -9,4 +9,9 @@ export const postLoginAdmin = async ({ phoneNumber, password }: PostLoginAuthReq
 
 export const deleteLogoutAdmin = async () => {
   await maru.delete('/auth', authorization());
+};
+
+export const getCheckLogin = async () => {
+  const { data } = await maru.get<GetCheckLoginRes>('/user', authorization());
+  return data;
 };

--- a/apps/admin/src/services/auth/mutations.ts
+++ b/apps/admin/src/services/auth/mutations.ts
@@ -26,11 +26,12 @@ export const useLoginAdminMutation = ({ phoneNumber, password }: PostLoginAuthRe
 };
 
 export const useLogoutAdminMutation = () => {
+  const router = useRouter();
   const { mutate: logoutAdminMutate, ...restMutation } = useMutation({
     mutationFn: deleteLogoutAdmin,
     onSuccess: () => {
       localStorage.clear();
-      window.location.href = ROUTES.MAIN;
+      router.replace(ROUTES.LOGIN);
     },
     onError: () => localStorage.clear(),
   });

--- a/apps/admin/src/services/auth/mutations.ts
+++ b/apps/admin/src/services/auth/mutations.ts
@@ -17,7 +17,7 @@ export const useLoginAdminMutation = ({ phoneNumber, password }: PostLoginAuthRe
       const { accessToken, refreshToken } = res.data;
       Storage.setItem(TOKEN.ACCESS, accessToken);
       Storage.setItem(TOKEN.REFRESH, refreshToken);
-      router.push(ROUTES.MAIN);
+      router.replace(ROUTES.MAIN);
     },
     onError: handleError,
   });

--- a/apps/admin/src/services/auth/queries.ts
+++ b/apps/admin/src/services/auth/queries.ts
@@ -1,0 +1,13 @@
+import { getCheckLogin } from './api';
+import { KEY } from '@/constants/common/constant';
+import { useQuery } from '@tanstack/react-query';
+
+export const useLoginCheckQuery = () => {
+  const { data, ...restQuery } = useQuery({
+    queryKey: [KEY.LOGIN_CHECK],
+    queryFn: getCheckLogin,
+    suspense: false,
+  });
+
+  return { data, ...restQuery };
+};

--- a/apps/admin/src/types/auth/client.ts
+++ b/apps/admin/src/types/auth/client.ts
@@ -1,0 +1,5 @@
+export interface CheckLoginType {
+  phoneNumber: string;
+  name: string;
+  authority: string;
+}

--- a/apps/admin/src/types/auth/remote.ts
+++ b/apps/admin/src/types/auth/remote.ts
@@ -1,4 +1,10 @@
+import type { CheckLoginType } from './client';
+
 export interface PostLoginAuthReq {
   phoneNumber: string;
   password: string;
+}
+
+export interface GetCheckLoginRes {
+  data: CheckLoginType;
 }


### PR DESCRIPTION
## 📄 Summary

> 어드민에서 로그아웃 버튼을 눌렀을 때 alert가 뜨지 않고 곧바로 로그인 페이지로 이동하도록 수정하였습니다.
> 어드민 페이지에 유저 계정으로 들어올 시 리다이렉트 기능을 추가 하였습니다.

<br>

## 🔨 Tasks

- 로그아웃 버튼을 누르실 로그인 페이지로 이동하도록 수정
- 로그인 타입이 어드민인지 유저인지 조회하는 기능 추가
- 어드민 페이지 유저 리다이렉트 기능 추가

<br>

## 🙋🏻 More
