### PR TITLE
bug(user): 졸업연도 라벨 수정 및 입력 수정

### DIFF
--- a/apps/user/src/app/form/출신학교및학력/출신학교및학력.hooks.ts
+++ b/apps/user/src/app/form/출신학교및학력/출신학교및학력.hooks.ts
@@ -24,6 +24,11 @@ export const useInput = () => {
 
   const handle출신학교및학력Change: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { name, value } = e.target;
+
+    if (name === 'graduationYear' && !/^\d*$/.test(value)) {
+      return;
+    }
+
     setForm((prev) => ({ ...prev, education: { ...prev.education, [name]: value } }));
   };
 

--- a/apps/user/src/app/form/출신학교및학력/출신학교및학력.tsx
+++ b/apps/user/src/app/form/출신학교및학력/출신학교및학력.tsx
@@ -61,7 +61,7 @@ const 출신학교및학력 = () => {
         <Row gap={48} alignItems="center">
           <Input
             name="graduationYear"
-            label="졸업 년도, 합격 년도"
+            label="졸업 연도, 합격 연도"
             placeholder="예) 2024"
             width="100%"
             value={form.education.graduationYear}


### PR DESCRIPTION
## 📄 Summary

>졸업 연도와 합격 연도의 맞춤법이 틀려서 수정하고 입력할때 문자와 특수문자는 입력되지 않고 숫자만 입력가능하도록 수정하였습니다.

<br>

## 🔨 Tasks

- 졸업 연도, 합격 연도 맞춤법 수정
- 숫자만 입력 가능하도록 수정

<br>

## 🙋🏻 More
