### PR TITLE
fix(user): 컴활 자격증 중복 인정 안되게 수정

### DIFF
--- a/apps/user/src/hooks/useGradeCaculation.ts
+++ b/apps/user/src/hooks/useGradeCaculation.ts
@@ -152,9 +152,9 @@ const useGradeCalculation = () => {
 
       if (form.grade.certificateList.includes('COMPUTER_SPECIALIST_LEVEL_1'))
         certificateScore += 3;
-      if (form.grade.certificateList.includes('COMPUTER_SPECIALIST_LEVEL_2'))
+      else if (form.grade.certificateList.includes('COMPUTER_SPECIALIST_LEVEL_2'))
         certificateScore += 2;
-      if (form.grade.certificateList.includes('COMPUTER_SPECIALIST_LEVEL_3'))
+      else if (form.grade.certificateList.includes('COMPUTER_SPECIALIST_LEVEL_3'))
         certificateScore += 1;
     }
 


### PR DESCRIPTION
## 📄 Summary

> 컴퓨터 활용 등급 자격증은 가장 높은 등급의 자격증만 점수로 인정하지만 높은 등급과 낮은 등급 둘 다 중복으로 인정하는 의도하지 않은 상황이 발생 했습니다. 컴퓨터 활용 등급 자격증 중복으로 인정이 안되게 수정 하였습니다.

<br>

## 🔨 Tasks

- 컴활 자격증 중복 인정 안되게 수정

<br>

## 🙋🏻 More
