### PR TITLE
fix(user): 최종 원서 여러번 다운로드

### DIFF
--- a/apps/user/src/app/form/최종제출/최종제출.hooks.ts
+++ b/apps/user/src/app/form/최종제출/최종제출.hooks.ts
@@ -50,7 +50,7 @@ export const useExportFormAction = (
     if (exportFormData && !hasDownloaded) {
       const blobUrl = window.URL.createObjectURL(new Blob([exportFormData]));
       setPdfBlobUrl(blobUrl);
-      downloadPdf(); // 다운로드 실행
+      downloadPdf();
       closePdfGeneratedLoader();
     } else if (!exportFormData) {
       openPdfGeneratedLoader();

--- a/apps/user/src/app/form/최종제출/최종제출.hooks.ts
+++ b/apps/user/src/app/form/최종제출/최종제출.hooks.ts
@@ -43,7 +43,6 @@ export const useExportFormAction = (
 
   useEffect(() => {
     if (exportFormData) {
-      downloadPdf();
       closePdfGeneratedLoader();
     } else {
       openPdfGeneratedLoader();
@@ -51,9 +50,11 @@ export const useExportFormAction = (
   }, [closePdfGeneratedLoader, downloadPdf, exportFormData, openPdfGeneratedLoader]);
 
   const handleExportForm = useCallback(() => {
-    downloadPdf();
-    closePdfGeneratedLoader();
-  }, [downloadPdf, closePdfGeneratedLoader]);
+    if (exportFormData) {
+      downloadPdf();
+      closePdfGeneratedLoader();
+    }
+  }, [downloadPdf, closePdfGeneratedLoader, exportFormData]);
 
   return { handleExportForm };
 };

--- a/apps/user/src/app/form/최종제출/최종제출.hooks.ts
+++ b/apps/user/src/app/form/최종제출/최종제출.hooks.ts
@@ -6,7 +6,7 @@ import {
 import { useExportFormQuery } from '@/services/form/queries';
 import { useFormDocumentValueStore, useSetFormDocumentStore } from '@/store';
 import type { ChangeEventHandler } from 'react';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useEffect } from 'react';
 
 export const useSubmitFinalFormAction = () => {
@@ -26,9 +26,12 @@ export const useExportFormAction = (
 ) => {
   const { userData } = useUser();
   const { data: exportFormData } = useExportFormQuery();
-  const pdfBlobUrl = window.URL.createObjectURL(new Blob([exportFormData]));
+  const [pdfBlobUrl, setPdfBlobUrl] = useState('');
+  const [hasDownloaded, setHasDownloaded] = useState(false);
 
   const downloadPdf = useCallback(() => {
+    if (!pdfBlobUrl) return;
+
     const link = document.createElement('a');
     link.href = pdfBlobUrl;
     link.setAttribute(
@@ -39,22 +42,38 @@ export const useExportFormAction = (
     link.click();
     link.remove();
     window.URL.revokeObjectURL(pdfBlobUrl);
+    setPdfBlobUrl('');
+    setHasDownloaded(true);
   }, [pdfBlobUrl, userData.name]);
 
   useEffect(() => {
-    if (exportFormData) {
+    if (exportFormData && !hasDownloaded) {
+      const blobUrl = window.URL.createObjectURL(new Blob([exportFormData]));
+      setPdfBlobUrl(blobUrl);
+      downloadPdf(); // 다운로드 실행
       closePdfGeneratedLoader();
+    } else if (!exportFormData) {
+      openPdfGeneratedLoader();
+    }
+  }, [
+    exportFormData,
+    hasDownloaded,
+    closePdfGeneratedLoader,
+    openPdfGeneratedLoader,
+    downloadPdf,
+  ]);
+
+  const handleExportForm = useCallback(() => {
+    if (pdfBlobUrl) {
+      downloadPdf();
+    } else if (exportFormData) {
+      const blobUrl = window.URL.createObjectURL(new Blob([exportFormData]));
+      setPdfBlobUrl(blobUrl);
+      downloadPdf();
     } else {
       openPdfGeneratedLoader();
     }
-  }, [closePdfGeneratedLoader, downloadPdf, exportFormData, openPdfGeneratedLoader]);
-
-  const handleExportForm = useCallback(() => {
-    if (exportFormData) {
-      downloadPdf();
-      closePdfGeneratedLoader();
-    }
-  }, [downloadPdf, closePdfGeneratedLoader, exportFormData]);
+  }, [downloadPdf, openPdfGeneratedLoader, exportFormData, pdfBlobUrl]);
 
   return { handleExportForm };
 };


### PR DESCRIPTION
## 📄 Summary

> 원서가 처음에 loader를 통해서 다운로드되고 사용자가 선택적으로 원서를 다운로드할수 있는 버튼에서만 다운로드가 가능해야 하는데 원서 업로드하고 나서 최종제출하고 나서 4개 정도의 원서가 추가적으로 다운로드 되는 현상을 수정하였습니다.

<br>

## 🔨 Tasks

- 로드에서만 다운로드되도록 수정
- 버튼 클릭시 추가 다운로드 가능하도록 수정
- 업로드및 최종 제출시 추가 다운로드 안되도록 수정

<br>

## 🙋🏻 More
