### PR TITLE
fix(admin): 접수번호를 수험번호로 보이도록 수정

### DIFF
--- a/apps/admin/src/components/common/SideBar/SideBar.tsx
+++ b/apps/admin/src/components/common/SideBar/SideBar.tsx
@@ -48,7 +48,7 @@ const SideBar = () => {
 
   return (
     <StyledSideBar>
-      <Link href={ROUTES.MAIN}>
+      <Link href={ROUTES.FORM}>
         <Image
           style={{
             position: 'absolute',

--- a/apps/admin/src/components/form/FormDetailContent/Profile/Profile.tsx
+++ b/apps/admin/src/components/form/FormDetailContent/Profile/Profile.tsx
@@ -35,7 +35,7 @@ const Profile = ({ id }: Props) => {
           <Row gap={10}>
             <IconBadge width={24} height={24} />
             <Text fontType="p2" color={color.gray900}>
-              {formDetailData?.applicant.name}
+              {formDetailData?.examinationNumber}
             </Text>
           </Row>
           <Row gap={10}>

--- a/apps/admin/src/components/form/FormTable/FormTable.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTable.tsx
@@ -14,6 +14,7 @@ const FormTable = () => {
         formList.map((item) => (
           <FormTableItem
             id={item.id}
+            examinationNumber={item.examinationNumber}
             name={item.name}
             birthday={item.birthday}
             graduationType={item.graduationType}

--- a/apps/admin/src/components/form/FormTable/FormTableHeader/FormTableHeader.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableHeader/FormTableHeader.tsx
@@ -33,7 +33,7 @@ const FormTableHeader = () => {
           <CheckBox onChange={handleAllFormToPrintSelectChange} />
         ) : null}
         <Text fontType="p2" width={60}>
-          접수번호
+          수험번호
         </Text>
         <Text fontType="p2" width={60}>
           이름

--- a/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
+++ b/apps/admin/src/components/form/FormTable/FormTableItem/FormTableItem.tsx
@@ -14,6 +14,7 @@ import styled from 'styled-components';
 
 const FormTableItem = ({
   id,
+  examinationNumber,
   name,
   graduationType,
   school,
@@ -115,7 +116,7 @@ const FormTableItem = ({
             />
           ) : null}
           <Text fontType="p2" width={60}>
-            {id}
+            {examinationNumber}
           </Text>
           <Text fontType="p2" width={60}>
             {name}

--- a/apps/admin/src/mocks/handlers/main.ts
+++ b/apps/admin/src/mocks/handlers/main.ts
@@ -4,6 +4,7 @@ import type { Form } from '@/types/form/client';
 const MAIN_FORM_DATA: Form[] = [
   {
     id: 0,
+    examinationNumber: 2000,
     name: '김밤돌',
     birthday: '2005-04-15',
     graduationType: 'EXPECTED',
@@ -17,6 +18,7 @@ const MAIN_FORM_DATA: Form[] = [
   },
   {
     id: 1,
+    examinationNumber: 2001,
     name: '김밤돌',
     birthday: '2005-04-15',
     graduationType: 'QUALIFICATION_EXAMINATION',
@@ -30,6 +32,7 @@ const MAIN_FORM_DATA: Form[] = [
   },
   {
     id: 2,
+    examinationNumber: 2002,
     name: '김밤돌',
     birthday: '2005-04-15',
     graduationType: 'EXPECTED',

--- a/apps/admin/src/types/form/client.ts
+++ b/apps/admin/src/types/form/client.ts
@@ -29,6 +29,7 @@ export type GraduationType = 'EXPECTED' | 'GRADUATED' | 'QUALIFICATION_EXAMINATI
 
 export interface Form {
   id: number;
+  examinationNumber: number | null;
   name: string;
   birthday: string;
   graduationType: GraduationType;
@@ -52,6 +53,7 @@ export type ExportExcelType =
 export type PassStatusType = '합격' | '불합격' | '미정';
 
 export interface FormDetail {
+  examinationNumber: number | null;
   applicant: UserInfo;
   parent: ParentInfo;
   education: EducationInfo;


### PR DESCRIPTION
## 📄 Summary

> 원서관리 및 상세 원서 페이지에서 이름과 접수번호로 나타났던것들을 수험번호로 보이도록 수정하도록했습니다.

<br>

## 🔨 Tasks

- 원서관리 페이지 접수번호를 수험번호로 수정
- 상세 원서페이지에서 이름을 수험번호로 수정

<br>

## 🙋🏻 More

https://github.com/Bamdoliro/marururu/assets/126876363/741c9676-98a9-41f5-9589-2aff27d0ec0a

