### PR TITLE
Feat/#574

### DIFF
--- a/apps/user/src/app/form/성적입력/교과성적.hooks.ts
+++ b/apps/user/src/app/form/성적입력/교과성적.hooks.ts
@@ -1,0 +1,31 @@
+import { useSaveFormMutation } from '@/services/form/mutations';
+import { useFormValueStore, useSetFormStepStore, useSet성적입력StepStore } from '@/store';
+
+export const useCTAButton = () => {
+  const form = useFormValueStore();
+  const setFormStep = useSetFormStepStore();
+  const set성적입력Step = useSet성적입력StepStore();
+  const { saveFormMutate } = useSaveFormMutation();
+
+  const handleMoveNextStep = () => {
+    const isEmptySubjectName = form.grade.subjectList.some(({ subjectName }) => {
+      if (subjectName === '') {
+        alert('비어있는 과목명이 있어요');
+        setFormStep('성적입력');
+        return true;
+      }
+      return false;
+    });
+
+    if (!isEmptySubjectName) {
+      set성적입력Step('출결상황');
+      saveFormMutate(form);
+    }
+  };
+
+  const handleMovePreviousStep = () => {
+    setFormStep('전형선택');
+  };
+
+  return { handleMoveNextStep, handleMovePreviousStep };
+};

--- a/apps/user/src/app/form/성적입력/교과성적.tsx
+++ b/apps/user/src/app/form/성적입력/교과성적.tsx
@@ -1,0 +1,47 @@
+import { FormController, GradePreview, ScoreCalculator } from '@/components/form';
+import { FormLayout } from '@/layouts';
+import { color } from '@maru/design-token';
+import { Column, Text, UnderlineButton } from '@maru/ui';
+import { flex } from '@maru/utils';
+import styled from 'styled-components';
+import { useCTAButton } from './교과성적.hooks';
+
+const 교과성적 = () => {
+  const { handleMoveNextStep, handleMovePreviousStep } = useCTAButton();
+
+  return (
+    <FormLayout title="성적 입력">
+      <Column gap={24}>
+        <Text fontType="p3" color={color.red}>
+          *교과성적이 없는 학기나 학년의 경우 모집요강을 반드시 확인 바랍니다.
+          <br />
+          *성취수준이 없고 원점수로 되어있는 학기나 학년은 아래표를 참고 바랍니다.
+        </Text>
+        <Column gap={12}>
+          <Text fontType="H4" color={color.gray900}>
+            모의 성적 계산
+          </Text>
+          <GradePreview />
+        </Column>
+      </Column>
+      <NavigationBar>
+        <UnderlineButton active={true}>교과성적</UnderlineButton>
+      </NavigationBar>
+      <ScoreCalculator option="FORM" />
+      <FormController
+        onPrevious={handleMovePreviousStep}
+        onNext={handleMoveNextStep}
+        step="성적입력"
+      />
+    </FormLayout>
+  );
+};
+
+export default 교과성적;
+
+const NavigationBar = styled.div`
+  ${flex({ alignItems: 'center' })}
+  width: 100%;
+  margin: 64px 0 16px;
+  background-color: ${color.white};
+`;

--- a/apps/user/src/app/form/성적입력/봉사시간.hooks.ts
+++ b/apps/user/src/app/form/성적입력/봉사시간.hooks.ts
@@ -1,9 +1,10 @@
 import { useSaveFormMutation } from '@/services/form/mutations';
-import { useFormValueStore, useSetFormStepStore } from '@/store';
+import { useFormValueStore, useSetFormStepStore, useSet성적입력StepStore } from '@/store';
 
 export const useCTAButton = () => {
   const form = useFormValueStore();
   const setFormStep = useSetFormStepStore();
+  const set성적입력Step = useSet성적입력StepStore();
   const { saveFormMutate } = useSaveFormMutation();
 
   const handleMoveNextStep = () => {
@@ -17,13 +18,13 @@ export const useCTAButton = () => {
     });
 
     if (!isEmptySubjectName) {
-      setFormStep('자기소개서');
+      set성적입력Step('자격증');
       saveFormMutate(form);
     }
   };
 
   const handleMovePreviousStep = () => {
-    setFormStep('전형선택');
+    set성적입력Step('출결상황');
   };
 
   return { handleMoveNextStep, handleMovePreviousStep };

--- a/apps/user/src/app/form/성적입력/봉사시간.tsx
+++ b/apps/user/src/app/form/성적입력/봉사시간.tsx
@@ -1,0 +1,47 @@
+import { FormController, GradePreview, VolunteerCalculator } from '@/components/form';
+import { FormLayout } from '@/layouts';
+import { color } from '@maru/design-token';
+import { Column, Text, UnderlineButton } from '@maru/ui';
+import { flex } from '@maru/utils';
+import styled from 'styled-components';
+import { useCTAButton } from './봉사시간.hooks';
+
+const 봉사시간 = () => {
+  const { handleMoveNextStep, handleMovePreviousStep } = useCTAButton();
+
+  return (
+    <FormLayout title="성적 입력">
+      <Column gap={24}>
+        <Text fontType="p3" color={color.red}>
+          *교과성적이 없는 학기나 학년의 경우 모집요강을 반드시 확인 바랍니다.
+          <br />
+          *성취수준이 없고 원점수로 되어있는 학기나 학년은 아래표를 참고 바랍니다.
+        </Text>
+        <Column gap={12}>
+          <Text fontType="H4" color={color.gray900}>
+            모의 성적 계산
+          </Text>
+          <GradePreview />
+        </Column>
+      </Column>
+      <NavigationBar>
+        <UnderlineButton active={true}>봉사시간</UnderlineButton>
+      </NavigationBar>
+      <VolunteerCalculator />
+      <FormController
+        onPrevious={handleMovePreviousStep}
+        onNext={handleMoveNextStep}
+        step="성적입력"
+      />
+    </FormLayout>
+  );
+};
+
+export default 봉사시간;
+
+const NavigationBar = styled.div`
+  ${flex({ alignItems: 'center' })}
+  width: 100%;
+  margin: 64px 0 16px;
+  background-color: ${color.white};
+`;

--- a/apps/user/src/app/form/성적입력/봉사시간.tsx
+++ b/apps/user/src/app/form/성적입력/봉사시간.tsx
@@ -5,8 +5,10 @@ import { Column, Text, UnderlineButton } from '@maru/ui';
 import { flex } from '@maru/utils';
 import styled from 'styled-components';
 import { useCTAButton } from './봉사시간.hooks';
+import { useFormValueStore } from '@/store';
 
 const 봉사시간 = () => {
+  const form = useFormValueStore();
   const { handleMoveNextStep, handleMovePreviousStep } = useCTAButton();
 
   return (
@@ -27,7 +29,11 @@ const 봉사시간 = () => {
       <NavigationBar>
         <UnderlineButton active={true}>봉사시간</UnderlineButton>
       </NavigationBar>
-      <VolunteerCalculator />
+      <VolunteerCalculatorWrapper
+        disabled={form.education.graduationType === 'QUALIFICATION_EXAMINATION'}
+      >
+        <VolunteerCalculator />
+      </VolunteerCalculatorWrapper>
       <FormController
         onPrevious={handleMovePreviousStep}
         onNext={handleMoveNextStep}
@@ -44,4 +50,13 @@ const NavigationBar = styled.div`
   width: 100%;
   margin: 64px 0 16px;
   background-color: ${color.white};
+`;
+
+const VolunteerCalculatorWrapper = styled.div<{ disabled: boolean }>`
+  ${({ disabled }) =>
+    disabled &&
+    `
+    pointer-events: none;
+    opacity: 0.5;
+  `}
 `;

--- a/apps/user/src/app/form/성적입력/성적입력.tsx
+++ b/apps/user/src/app/form/성적입력/성적입력.tsx
@@ -1,88 +1,25 @@
-import {
-  AttendanceCalculator,
-  CertificateCalculator,
-  FormController,
-  GradePreview,
-  ScoreCalculator,
-  VolunteerCalculator,
-} from '@/components/form';
-import { SCORE_STEP_LIST } from '@/constants/form/data';
-import { FormLayout } from '@/layouts';
-import { useFormValueStore } from '@/store';
-import { color } from '@maru/design-token';
-import { Column, Text, UnderlineButton } from '@maru/ui';
-import { flex } from '@maru/utils';
 import { SwitchCase } from '@toss/react';
-import { useState } from 'react';
-import styled from 'styled-components';
-import { useCTAButton } from './성적입력.hooks';
+import 교과성적 from './교과성적';
+import 출결상황 from './출결상황';
+import { use성적입력StepStore } from '@/store';
+import 봉사시간 from './봉사시간';
+import 자격증 from './자격증';
 
 const 성적입력 = () => {
-  const form = useFormValueStore();
-  const [currentScoreStep, setCurrentScoreStep] = useState('성적 입력');
-  const { handleMoveNextStep, handleMovePreviousStep } = useCTAButton();
-
-  const handleScoreStepButtonClick = (scoreStep: string) => {
-    if (
-      form.education.graduationType === 'QUALIFICATION_EXAMINATION' &&
-      (scoreStep === '출결상황' || scoreStep === '봉사시간')
-    ) {
-      alert('검정고시 지원자는 입력하지 않아도돼요.');
-      return;
-    }
-    setCurrentScoreStep(scoreStep);
-  };
+  const [성적입력Step] = use성적입력StepStore();
 
   return (
-    <FormLayout title="성적 입력">
-      <Column gap={24}>
-        <Text fontType="p3" color={color.red}>
-          *교과성적이 없는 학기나 학년의 경우 모집요강을 반드시 확인 바랍니다.
-          <br />
-          *성취수준이 없고 원점수로 되어있는 학기나 학년은 아래표를 참고 바랍니다.
-        </Text>
-        <Column gap={12}>
-          <Text fontType="H4" color={color.gray900}>
-            모의 성적 계산
-          </Text>
-          <GradePreview />
-        </Column>
-      </Column>
-      <NavigationBar>
-        {SCORE_STEP_LIST.map((scoreStep, index) => (
-          <UnderlineButton
-            key={`score-step ${index}`}
-            active={scoreStep === currentScoreStep}
-            onClick={() => handleScoreStepButtonClick(scoreStep)}
-          >
-            {scoreStep}
-          </UnderlineButton>
-        ))}
-      </NavigationBar>
-      <SwitchCase
-        value={currentScoreStep}
-        caseBy={{
-          성적입력: <ScoreCalculator option="FORM" />,
-          출결상황: <AttendanceCalculator />,
-          봉사시간: <VolunteerCalculator />,
-          자격증: <CertificateCalculator />,
-        }}
-        defaultComponent={<ScoreCalculator option="FORM" />}
-      />
-      <FormController
-        onPrevious={handleMovePreviousStep}
-        onNext={handleMoveNextStep}
-        step="성적입력"
-      />
-    </FormLayout>
+    <SwitchCase
+      value={성적입력Step}
+      caseBy={{
+        교과성적: <교과성적 />,
+        출결상황: <출결상황 />,
+        봉사시간: <봉사시간 />,
+        자격증: <자격증 />,
+      }}
+      defaultComponent={<교과성적 />}
+    />
   );
 };
 
 export default 성적입력;
-
-const NavigationBar = styled.div`
-  ${flex({ alignItems: 'center' })}
-  width: 100%;
-  margin: 64px 0 16px;
-  background-color: ${color.white};
-`;

--- a/apps/user/src/app/form/성적입력/자격증.hooks.ts
+++ b/apps/user/src/app/form/성적입력/자격증.hooks.ts
@@ -1,0 +1,31 @@
+import { useSaveFormMutation } from '@/services/form/mutations';
+import { useFormValueStore, useSetFormStepStore, useSet성적입력StepStore } from '@/store';
+
+export const useCTAButton = () => {
+  const form = useFormValueStore();
+  const setFormStep = useSetFormStepStore();
+  const set성적입력Step = useSet성적입력StepStore();
+  const { saveFormMutate } = useSaveFormMutation();
+
+  const handleMoveNextStep = () => {
+    const isEmptySubjectName = form.grade.subjectList.some(({ subjectName }) => {
+      if (subjectName === '') {
+        alert('비어있는 과목명이 있어요');
+        setFormStep('성적입력');
+        return true;
+      }
+      return false;
+    });
+
+    if (!isEmptySubjectName) {
+      setFormStep('자기소개서');
+      saveFormMutate(form);
+    }
+  };
+
+  const handleMovePreviousStep = () => {
+    set성적입력Step('봉사시간');
+  };
+
+  return { handleMoveNextStep, handleMovePreviousStep };
+};

--- a/apps/user/src/app/form/성적입력/자격증.tsx
+++ b/apps/user/src/app/form/성적입력/자격증.tsx
@@ -1,0 +1,47 @@
+import { CertificateCalculator, FormController, GradePreview } from '@/components/form';
+import { FormLayout } from '@/layouts';
+import { color } from '@maru/design-token';
+import { Column, Text, UnderlineButton } from '@maru/ui';
+import { flex } from '@maru/utils';
+import styled from 'styled-components';
+import { useCTAButton } from './자격증.hooks';
+
+const 자격증 = () => {
+  const { handleMoveNextStep, handleMovePreviousStep } = useCTAButton();
+
+  return (
+    <FormLayout title="성적 입력">
+      <Column gap={24}>
+        <Text fontType="p3" color={color.red}>
+          *교과성적이 없는 학기나 학년의 경우 모집요강을 반드시 확인 바랍니다.
+          <br />
+          *성취수준이 없고 원점수로 되어있는 학기나 학년은 아래표를 참고 바랍니다.
+        </Text>
+        <Column gap={12}>
+          <Text fontType="H4" color={color.gray900}>
+            모의 성적 계산
+          </Text>
+          <GradePreview />
+        </Column>
+      </Column>
+      <NavigationBar>
+        <UnderlineButton active={true}>자격증</UnderlineButton>
+      </NavigationBar>
+      <CertificateCalculator />
+      <FormController
+        onPrevious={handleMovePreviousStep}
+        onNext={handleMoveNextStep}
+        step="성적입력"
+      />
+    </FormLayout>
+  );
+};
+
+export default 자격증;
+
+const NavigationBar = styled.div`
+  ${flex({ alignItems: 'center' })}
+  width: 100%;
+  margin: 64px 0 16px;
+  background-color: ${color.white};
+`;

--- a/apps/user/src/app/form/성적입력/출결상황.hooks.ts
+++ b/apps/user/src/app/form/성적입력/출결상황.hooks.ts
@@ -1,0 +1,31 @@
+import { useSaveFormMutation } from '@/services/form/mutations';
+import { useFormValueStore, useSetFormStepStore, useSet성적입력StepStore } from '@/store';
+
+export const useCTAButton = () => {
+  const form = useFormValueStore();
+  const setFormStep = useSetFormStepStore();
+  const set성적입력Step = useSet성적입력StepStore();
+  const { saveFormMutate } = useSaveFormMutation();
+
+  const handleMoveNextStep = () => {
+    const isEmptySubjectName = form.grade.subjectList.some(({ subjectName }) => {
+      if (subjectName === '') {
+        alert('비어있는 과목명이 있어요');
+        setFormStep('성적입력');
+        return true;
+      }
+      return false;
+    });
+
+    if (!isEmptySubjectName) {
+      set성적입력Step('봉사시간');
+      saveFormMutate(form);
+    }
+  };
+
+  const handleMovePreviousStep = () => {
+    set성적입력Step('교과성적');
+  };
+
+  return { handleMoveNextStep, handleMovePreviousStep };
+};

--- a/apps/user/src/app/form/성적입력/출결상황.tsx
+++ b/apps/user/src/app/form/성적입력/출결상황.tsx
@@ -1,0 +1,47 @@
+import { AttendanceCalculator, FormController, GradePreview } from '@/components/form';
+import { FormLayout } from '@/layouts';
+import { color } from '@maru/design-token';
+import { Column, Text, UnderlineButton } from '@maru/ui';
+import { flex } from '@maru/utils';
+import styled from 'styled-components';
+import { useCTAButton } from './출결상황.hooks';
+
+const 출결상황 = () => {
+  const { handleMoveNextStep, handleMovePreviousStep } = useCTAButton();
+
+  return (
+    <FormLayout title="성적 입력">
+      <Column gap={24}>
+        <Text fontType="p3" color={color.red}>
+          *교과성적이 없는 학기나 학년의 경우 모집요강을 반드시 확인 바랍니다.
+          <br />
+          *성취수준이 없고 원점수로 되어있는 학기나 학년은 아래표를 참고 바랍니다.
+        </Text>
+        <Column gap={12}>
+          <Text fontType="H4" color={color.gray900}>
+            모의 성적 계산
+          </Text>
+          <GradePreview />
+        </Column>
+      </Column>
+      <NavigationBar>
+        <UnderlineButton active={true}>출결 상황</UnderlineButton>
+      </NavigationBar>
+      <AttendanceCalculator />
+      <FormController
+        onPrevious={handleMovePreviousStep}
+        onNext={handleMoveNextStep}
+        step="성적입력"
+      />
+    </FormLayout>
+  );
+};
+
+export default 출결상황;
+
+const NavigationBar = styled.div`
+  ${flex({ alignItems: 'center' })}
+  width: 100%;
+  margin: 64px 0 16px;
+  background-color: ${color.white};
+`;

--- a/apps/user/src/app/form/성적입력/출결상황.tsx
+++ b/apps/user/src/app/form/성적입력/출결상황.tsx
@@ -5,8 +5,10 @@ import { Column, Text, UnderlineButton } from '@maru/ui';
 import { flex } from '@maru/utils';
 import styled from 'styled-components';
 import { useCTAButton } from './출결상황.hooks';
+import { useFormValueStore } from '@/store';
 
 const 출결상황 = () => {
+  const form = useFormValueStore();
   const { handleMoveNextStep, handleMovePreviousStep } = useCTAButton();
 
   return (
@@ -27,7 +29,11 @@ const 출결상황 = () => {
       <NavigationBar>
         <UnderlineButton active={true}>출결 상황</UnderlineButton>
       </NavigationBar>
-      <AttendanceCalculator />
+      <AttendanceCalculatorWrapper
+        disabled={form.education.graduationType === 'QUALIFICATION_EXAMINATION'}
+      >
+        <AttendanceCalculator />
+      </AttendanceCalculatorWrapper>
       <FormController
         onPrevious={handleMovePreviousStep}
         onNext={handleMoveNextStep}
@@ -44,4 +50,13 @@ const NavigationBar = styled.div`
   width: 100%;
   margin: 64px 0 16px;
   background-color: ${color.white};
+`;
+
+const AttendanceCalculatorWrapper = styled.div<{ disabled: boolean }>`
+  ${({ disabled }) =>
+    disabled &&
+    `
+    pointer-events: none;
+    opacity: 0.5;
+  `}
 `;

--- a/apps/user/src/components/form/Calculators/AttendanceCalculator/AttendanceCalculator.tsx
+++ b/apps/user/src/components/form/Calculators/AttendanceCalculator/AttendanceCalculator.tsx
@@ -9,6 +9,8 @@ const AttendanceCalculator = () => {
   const form = useFormValueStore();
   const { handleAttendanceInfoChange } = useInput();
 
+  const isReadOnly = form.education.graduationType === 'QUALIFICATION_EXAMINATION';
+
   return (
     <StyledAttendanceCalculator>
       <Text fontType="p3" color={color.red}>
@@ -42,6 +44,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance1.absenceCount}
               isError={Number(form.grade.attendance1.absenceCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
           <Td width="100%" height={56}>
@@ -50,6 +53,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance1.latenessCount}
               isError={Number(form.grade.attendance1.latenessCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
           <Td width="100%" height={56}>
@@ -58,6 +62,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance1.earlyLeaveCount}
               isError={Number(form.grade.attendance1.earlyLeaveCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
           <Td width="100%" height={56}>
@@ -66,6 +71,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance1.classAbsenceCount}
               isError={Number(form.grade.attendance1.classAbsenceCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
         </Row>
@@ -79,6 +85,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance2.absenceCount}
               isError={Number(form.grade.attendance2.absenceCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
           <Td width="100%" height={56}>
@@ -87,6 +94,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance2.latenessCount}
               isError={Number(form.grade.attendance2.latenessCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
           <Td width="100%" height={56}>
@@ -95,6 +103,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance2.earlyLeaveCount}
               isError={Number(form.grade.attendance2.earlyLeaveCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
           <Td width="100%" height={56}>
@@ -103,6 +112,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance2.classAbsenceCount}
               isError={Number(form.grade.attendance2.classAbsenceCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
         </Row>
@@ -116,6 +126,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance3.absenceCount}
               isError={Number(form.grade.attendance3.absenceCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
           <Td width="100%" height={56}>
@@ -124,6 +135,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance3.latenessCount}
               isError={Number(form.grade.attendance3.latenessCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
           <Td width="100%" height={56}>
@@ -132,6 +144,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance3.earlyLeaveCount}
               isError={Number(form.grade.attendance3.earlyLeaveCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
           <Td borderBottomRightRadius={12} width="100%" height={56}>
@@ -140,6 +153,7 @@ const AttendanceCalculator = () => {
               onChange={handleAttendanceInfoChange}
               value={form.grade.attendance3.classAbsenceCount}
               isError={Number(form.grade.attendance3.classAbsenceCount) < 0}
+              readOnly={isReadOnly}
             />
           </Td>
         </Row>

--- a/apps/user/src/components/form/Calculators/VolunteerCalculator/VolunteerCalculator.tsx
+++ b/apps/user/src/components/form/Calculators/VolunteerCalculator/VolunteerCalculator.tsx
@@ -9,6 +9,8 @@ const VolunteerCalculator = () => {
   const form = useFormValueStore();
   const { handleVolunteerTimeChange } = useInput();
 
+  const isReadOnly = form.education.graduationType === 'QUALIFICATION_EXAMINATION';
+
   return (
     <StyledVolunteerCalculator>
       <Text fontType="p3" color={color.red}>
@@ -33,6 +35,7 @@ const VolunteerCalculator = () => {
               onChange={handleVolunteerTimeChange}
               value={form.grade.volunteerTime1}
               isError={Number(form.grade.volunteerTime1) < 0}
+              readOnly={isReadOnly}
             />
             <Hour>시간</Hour>
           </Td>
@@ -47,6 +50,7 @@ const VolunteerCalculator = () => {
               onChange={handleVolunteerTimeChange}
               value={form.grade.volunteerTime2}
               isError={Number(form.grade.volunteerTime2) < 0}
+              readOnly={isReadOnly}
             />
             <Hour>시간</Hour>
           </Td>
@@ -61,6 +65,7 @@ const VolunteerCalculator = () => {
               onChange={handleVolunteerTimeChange}
               value={form.grade.volunteerTime3}
               isError={Number(form.grade.volunteerTime3) < 0}
+              readOnly={isReadOnly}
             />
             <Hour>시간</Hour>
           </Td>

--- a/apps/user/src/store/form/성적입력Step.ts
+++ b/apps/user/src/store/form/성적입력Step.ts
@@ -1,0 +1,11 @@
+import { atom, useRecoilState, useSetRecoilState } from 'recoil';
+import type { 성적입력Step } from '@/types/form/client';
+
+const 성적입력StepAtomState = atom<성적입력Step>({
+  key: '성적입력-step',
+  default: '교과성적',
+});
+
+// eslint-disable-next-line react-hooks/rules-of-hooks
+export const use성적입력StepStore = () => useRecoilState(성적입력StepAtomState);
+export const useSet성적입력StepStore = () => useSetRecoilState(성적입력StepAtomState);

--- a/apps/user/src/store/index.ts
+++ b/apps/user/src/store/index.ts
@@ -27,3 +27,5 @@ export {
   useGEDSubjectListValueStore,
 } from './form/GEDSubjectList';
 export { useUserStore } from './user/user';
+
+export { use성적입력StepStore, useSet성적입력StepStore } from './form/성적입력Step';

--- a/apps/user/src/types/form/client.ts
+++ b/apps/user/src/types/form/client.ts
@@ -31,6 +31,8 @@ export type FormStep =
   | '최종제출'
   | '최종제출완료';
 
+export type 성적입력Step = '교과성적' | '출결상황' | '봉사시간' | '자격증';
+
 export interface User {
   identificationPictureUri: string;
   name: string;


### PR DESCRIPTION
## 📄 Summary

> QA를 진행하면서 학생들에게 원서를 넣을 때 중학교때의 성적으로 넣어달라고 요청하였는데 이때 성적은 잘 입력했지만 자격증, 출결, 봉사시간은 입력하지 않은 경우가 많아 이를 해결하고자 페이지를 나누어 보여주도록 변경되어 이에 맞게 수정 개발했습니다.

<br>

## 🔨 Tasks

- 페이지 분할
- 다음버튼 클릭시 이동 페이지 수정
- 검정고시일 경우 disable로 봉사와 출결 입력 불가하도록 수정

<br>

## 🙋🏻 More

https://github.com/Bamdoliro/marururu/assets/126876363/cf20c760-a33d-4f2c-8e3d-a8371846cb9e

