### PR TITLE
fix(user): 로그인한 유저가 원서를 작성할때 이름과 전화번호는 자동으로 입력되어 있도록 수정

### DIFF
--- a/apps/user/src/app/form/지원자정보/지원자정보.hooks.ts
+++ b/apps/user/src/app/form/지원자정보/지원자정보.hooks.ts
@@ -1,7 +1,9 @@
-import { useSaveFormMutation } from '@/services/form/mutations';
-import { useFormValueStore, useSetFormStepStore, useSetFormStore } from '@/store';
-import { formatDate } from '@/utils';
 import type { ChangeEventHandler } from 'react';
+import { useEffect } from 'react';
+import { useFormValueStore, useSetFormStepStore, useSetFormStore } from '@/store';
+import useUser from '@/hooks/useUser';
+import { formatDate } from '@/utils';
+import { useSaveFormMutation } from '@/services/form/mutations';
 
 export const useCTAButton = () => {
   const form = useFormValueStore();
@@ -18,6 +20,20 @@ export const useCTAButton = () => {
 
 export const useInput = () => {
   const setForm = useSetFormStore();
+  const user = useUser();
+
+  useEffect(() => {
+    if (user.userData.name && user.userData.phoneNumber) {
+      setForm((prev) => ({
+        ...prev,
+        applicant: {
+          ...prev.applicant,
+          name: user.userData.name,
+          phoneNumber: user.userData.phoneNumber,
+        },
+      }));
+    }
+  }, [setForm, user.userData]);
 
   const handle지원자정보Change: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { name, value } = e.target;
@@ -28,6 +44,8 @@ export const useInput = () => {
       }));
       return;
     }
+
+    if (name === 'name' || name === 'phoneNumber') return;
 
     setForm((prev) => ({ ...prev, applicant: { ...prev.applicant, [name]: value } }));
   };

--- a/apps/user/src/app/form/지원자정보/지원자정보.tsx
+++ b/apps/user/src/app/form/지원자정보/지원자정보.tsx
@@ -23,6 +23,7 @@ const 지원자정보 = () => {
             width="100%"
             isError={form.applicant.name.length > 20}
             errorMessage="20자 이하여야 합니다."
+            readOnly
           />
           <Input
             label="생년월일"
@@ -55,6 +56,7 @@ const 지원자정보 = () => {
               !!form.applicant.phoneNumber && form.applicant.phoneNumber.length !== 11
             }
             errorMessage="11글자여야 합니다"
+            readOnly
           />
         </Column>
       </Row>


### PR DESCRIPTION
## 📄 Summary

> 사용자 개선을 위해서 로그인한 유저의 전번과 이름을 가져와서 자동으로 입력되고 이걸로 원서를 작성하도록 하였습니다. 또한, 이름과 전번이 자동으로 입력된 후 수정할 수 없도록 하였습니다.

<br>

## 🔨 Tasks

- 로그인한 유저의 이름 가져와 input의 value 수정
- 로그인한 유저의 전화번호을 가져와 input의 value 수정

<br>

## 🙋🏻 More
