### PR TITLE
fix(user): 원서상태에 따른 원서작성 접근 변경

### DIFF
--- a/apps/user/src/components/common/Wrappers/FormWrapper/FormStatusManager/FormStatusManager.tsx
+++ b/apps/user/src/components/common/Wrappers/FormWrapper/FormStatusManager/FormStatusManager.tsx
@@ -9,16 +9,13 @@ const FormStatusManager = () => {
   useEffect(() => {
     if (formStatusData) {
       const { status } = formStatusData;
-      switch (status) {
-        case 'SUBMITTED':
-          setFormStep('초안제출완료');
-          break;
-        case 'FINAL_SUBMITTED':
-          setFormStep('최종제출완료');
-          break;
-        default:
-          break;
-      }
+      if (status === 'SUBMITTED') setFormStep('초안제출완료');
+      else if (
+        status === 'RECEIVED' ||
+        status === 'APPROVED' ||
+        status === 'FINAL_SUBMITTED'
+      )
+        setFormStep('최종제출완료');
     }
   }, [formStatusData, setFormStep]);
 


### PR DESCRIPTION
## 📄 Summary

> 원래는 FINAL_SUBMITTED 만이 최종제출완료 페이지에 접근 하게 되었는데, 이제 RECEIVED와 APPROVED도 최종제출완료 페이지에 접근 하게 되었습니다.

<br>

## 🔨 Tasks

- 원서 상태에 따른 원서 작성-최종제출완료 페이지 접근 상태 확대

<br>

## 🙋🏻 More
