### PR TITLE
fix(user): 특정 과목 성취도가 '-'일 경우 'C'로 처리 하는 기능 추가

### DIFF
--- a/apps/user/src/hooks/useGradeCaculation.ts
+++ b/apps/user/src/hooks/useGradeCaculation.ts
@@ -36,9 +36,17 @@ const useGradeCalculation = () => {
   const form = useFormValueStore();
 
   const getScoreOf = (achievementLevelKey: AchievementLevelKey) => {
+    let flag: number = 0;
     const scoreTotal = form.grade.subjectList?.reduce((acc, subject) => {
       const achievementLevel = subject[achievementLevelKey];
       const subjectName = subject.subjectName;
+      if (
+        (subjectName === '국어' || subjectName === '수학' || subjectName === '영어') &&
+        achievementLevel === null
+      ) {
+        flag += 1;
+        return acc + AchievementScore['C'];
+      }
       if (subjectName === '수학' && achievementLevel !== null) {
         return acc + AchievementScore[achievementLevel] * 2;
       } else {
@@ -47,7 +55,9 @@ const useGradeCalculation = () => {
     }, 0);
     const scoreLength =
       form.grade.subjectList?.filter((subject) => subject[achievementLevelKey] !== null)
-        .length + 1;
+        .length +
+      1 +
+      flag;
 
     return scoreTotal / scoreLength;
   };

--- a/apps/user/src/hooks/useGradeCaculation.ts
+++ b/apps/user/src/hooks/useGradeCaculation.ts
@@ -36,7 +36,7 @@ const useGradeCalculation = () => {
   const form = useFormValueStore();
 
   const getScoreOf = (achievementLevelKey: AchievementLevelKey) => {
-    let flag: number = 0;
+    let hyphenLength = 0;
     const scoreTotal = form.grade.subjectList?.reduce((acc, subject) => {
       const achievementLevel = subject[achievementLevelKey];
       const subjectName = subject.subjectName;
@@ -44,7 +44,7 @@ const useGradeCalculation = () => {
         (subjectName === '국어' || subjectName === '수학' || subjectName === '영어') &&
         achievementLevel === null
       ) {
-        flag += 1;
+        hyphenLength += 1;
         return acc + AchievementScore['C'];
       }
       if (subjectName === '수학' && achievementLevel !== null) {
@@ -57,7 +57,7 @@ const useGradeCalculation = () => {
       form.grade.subjectList?.filter((subject) => subject[achievementLevelKey] !== null)
         .length +
       1 +
-      flag;
+      hyphenLength;
 
     return scoreTotal / scoreLength;
   };


### PR DESCRIPTION
## 📄 Summary

> 2024년도 기준, 국어와 영어 그리고 수학의 성취도가 '-'일 경우 'C' 점수로 처리 하되 화면에는 '-'으로 유지하는 기능을 추가 하였습니다.

<br>

## 🔨 Tasks

- 국어와 수학 그리고 영어가 '-'인 경우에 'C'점수로 처리
- 국어와 수학 그리고 영어가 '-'인 경우에도 평균에 포함되도록 처리

<br>

## 🙋🏻 More
