### PR TITLE
fix(user): 초안제출 경고 문구 수정 및 버튼 수정

### DIFF
--- a/apps/user/src/components/form/DraftFormConfirm/DraftFormConfirm.tsx
+++ b/apps/user/src/components/form/DraftFormConfirm/DraftFormConfirm.tsx
@@ -51,6 +51,10 @@ const DraftFormConfirm = ({ isOpen, onClose, onConfirm }: Props) => {
       onClose={onClose}
       onConfirm={isInputValid ? onConfirm : () => {}}
       confirmButtonText="원서 초안 제출하기"
+      confirmButtonStyle={{
+        backgroundColor: isInputValid ? color.maruDefault : color.gray500,
+        cursor: isInputValid ? 'pointer' : 'unset',
+      }}
     />
   );
 };

--- a/apps/user/src/components/form/DraftFormConfirm/DraftFormConfirm.tsx
+++ b/apps/user/src/components/form/DraftFormConfirm/DraftFormConfirm.tsx
@@ -29,20 +29,17 @@ const DraftFormConfirm = ({ isOpen, onClose, onConfirm }: Props) => {
             <br />
             처리되며 더 이상 입학원서 수정이 불가능합니다.
           </Text>
-          <Text color={color.gray900} fontType="p2">
-            잘못 입력한 곳이 없는지 면밀히 검토해주시기 바랍니다.
-          </Text>
           <Column height={28}> </Column>
           <Text color={color.gray900} fontType="p2">
-            ‘확인했습니다'를 입력할 시 그 이후 발생하는 사고에는
-            부산소프트웨어마이스터고등
-            <br />
-            학교와{' '}
-            <Text color={color.red} fontType="p2">
-              밤돌이로팀은 전혀 책임지지 않음에 동의하는 것으로 간주됩니다.
+            원서 초안을 다시 한번 확인 하시고 잘못 입력한 부분이 없다고 판단되시는 경우
+            아래
+            <br />의 입력 칸에{' '}
+            <Text fontType="H5" color={color.gray900}>
+              ‘확인했습니다’
             </Text>
+            를 입력해 주세요.
           </Text>
-          <Column height={8}> </Column>
+          <Column height={30}> </Column>
           <CheckInput
             width="100%"
             placeholder="'확인했습니다'를 정확하게 입력해주세요"

--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -1,7 +1,8 @@
-import { IconAdd, IconShortcuts } from '@maru/icon';
 import { color } from '@maru/design-token';
+import { IconAdd, IconShortcuts } from '@maru/icon';
 import { flex } from '@maru/utils';
 import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { getButtonPadding, getButtonSize, getButtonStyle } from './Button.style';
 import type { ButtonIcon, ButtonSize, ButtonStyleType } from './Button.type';

--- a/packages/ui/src/Confirm/Confirm.tsx
+++ b/packages/ui/src/Confirm/Confirm.tsx
@@ -1,7 +1,8 @@
-import { IconClose } from '@maru/icon';
 import { color } from '@maru/design-token';
+import { IconClose } from '@maru/icon';
 import { flex } from '@maru/utils';
 import type { CSSProperties, ReactNode } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import Button from '../Button/Button';
 import Column from '../Flex/Column';
@@ -18,6 +19,7 @@ interface Props {
   confirmButtonText?: string;
   closeButtonText?: string;
   height?: CSSProperties['height'];
+  confirmButtonStyle?: CSSProperties;
 }
 
 const Confirm = ({
@@ -30,6 +32,7 @@ const Confirm = ({
   confirmButtonText = '확인',
   closeButtonText = '취소',
   height = 449,
+  confirmButtonStyle,
 }: Props) => {
   return (
     <BlurBackground $isOpen={isOpen}>
@@ -65,7 +68,7 @@ const Confirm = ({
           <Button styleType="SECONDARY" size="SMALL" onClick={onClose}>
             {closeButtonText}
           </Button>
-          <Button size="SMALL" onClick={onConfirm}>
+          <Button size="SMALL" onClick={onConfirm} style={confirmButtonStyle}>
             {confirmButtonText}
           </Button>
         </Row>

--- a/packages/ui/src/Confirm/Confirm.tsx
+++ b/packages/ui/src/Confirm/Confirm.tsx
@@ -92,7 +92,7 @@ const BlurBackground = styled.div<{ $isOpen: boolean }>`
 const StyledConfirm = styled.div`
   ${flex({ flexDirection: 'column', justifyContent: 'space-between' })}
   width: 600px;
-  padding: 36px;
+  padding: 40px;
   background-color: ${color.white};
   border-radius: 16px;
 `;


### PR DESCRIPTION
## 📄 Summary

> 초안제출 시 경고문구가 날카롭다는 교무부의 의견반영으로 수정하였습니다. 또, 확인했습니다라는 문구를 정확하게 입력하지않으면 제출 버튼이 활성화가 되지 않는 형식으로 수정하였습니다.

<br>

## 🔨 Tasks

- 경고문구 수정
- 값이 정확하지 않으면 버튼 비활성화

<br>

## 🙋🏻 More

https://github.com/Bamdoliro/marururu/assets/126876363/85c3d661-cabe-4e49-8272-a46d1c858a71
