### PR TITLE
fix(admin): 입학 전형 요강에 따른 원서 타입 명칭 변경

### DIFF
--- a/apps/admin/src/components/analysis/ApplyingType/ApplyingTypeDetail/ApplyingTypeDetail.tsx
+++ b/apps/admin/src/components/analysis/ApplyingType/ApplyingTypeDetail/ApplyingTypeDetail.tsx
@@ -111,7 +111,7 @@ const ApplyingTypeDetail = () => {
               </Row>
               <Row>
                 <Td width={240} height={56}>
-                  북한이탈주민 또는 그 자녀
+                  북한이탈청소년
                 </Td>
                 <Td width={80} height={56}>
                   {fromNorthKoreaApplicant}

--- a/apps/admin/src/components/analysis/ApplyingType/ApplyingTypeDetail/ApplyingTypeDetail.tsx
+++ b/apps/admin/src/components/analysis/ApplyingType/ApplyingTypeDetail/ApplyingTypeDetail.tsx
@@ -126,7 +126,7 @@ const ApplyingTypeDetail = () => {
             <Column>
               <Row>
                 <Td width={240} height={56}>
-                  다문화가정 자녀
+                  다문화가족 자녀
                 </Td>
                 <Td width={80} height={56}>
                   {multiculturalApplicant}

--- a/apps/admin/src/components/analysis/ApplyingType/ApplyingTypeDetail/ApplyingTypeDetail.tsx
+++ b/apps/admin/src/components/analysis/ApplyingType/ApplyingTypeDetail/ApplyingTypeDetail.tsx
@@ -73,7 +73,7 @@ const ApplyingTypeDetail = () => {
             </Td>
           </Row>
           <Row>
-            <Td width={240} height={280}>
+            <Td width={240} height={224}>
               기회균등 전형
             </Td>
             <Column>
@@ -109,6 +109,13 @@ const ApplyingTypeDetail = () => {
                   {oneParentApplicant}
                 </Td>
               </Row>
+            </Column>
+          </Row>
+          <Row>
+            <Td width={240} height={280}>
+              사회다양성 전형
+            </Td>
+            <Column>
               <Row>
                 <Td width={240} height={56}>
                   북한이탈청소년
@@ -117,13 +124,6 @@ const ApplyingTypeDetail = () => {
                   {fromNorthKoreaApplicant}
                 </Td>
               </Row>
-            </Column>
-          </Row>
-          <Row>
-            <Td width={240} height={224}>
-              사회다양성 전형
-            </Td>
-            <Column>
               <Row>
                 <Td width={240} height={56}>
                   다문화가족 자녀

--- a/apps/admin/src/components/analysis/ApplyingType/ApplyingTypeDetail/ApplyingTypeDetail.tsx
+++ b/apps/admin/src/components/analysis/ApplyingType/ApplyingTypeDetail/ApplyingTypeDetail.tsx
@@ -103,7 +103,7 @@ const ApplyingTypeDetail = () => {
               </Row>
               <Row>
                 <Td width={240} height={56}>
-                  한부모가정보호대상자
+                  한부모가정
                 </Td>
                 <Td width={80} height={56}>
                   {oneParentApplicant}

--- a/apps/admin/src/components/analysis/GradeDistribution/FinalRoundPassed/FinalRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/FinalRoundPassed/FinalRoundPassedDetail.tsx
@@ -88,7 +88,7 @@ const FinalRoundPassedDetail = () => {
             </Td>
           </Row>
           <Row>
-            <Td width={240} height={280}>
+            <Td width={240} height={224}>
               기회균등 전형
             </Td>
             <Column>
@@ -136,6 +136,13 @@ const FinalRoundPassedDetail = () => {
                   {oneParentApplicant.min}
                 </Td>
               </Row>
+            </Column>
+          </Row>
+          <Row>
+            <Td width={240} height={280}>
+              사회다양성 전형
+            </Td>
+            <Column>
               <Row>
                 <Td width={240} height={56}>
                   북한이탈청소년
@@ -147,13 +154,6 @@ const FinalRoundPassedDetail = () => {
                   {fromNorthKoreaApplicant.min}
                 </Td>
               </Row>
-            </Column>
-          </Row>
-          <Row>
-            <Td width={240} height={224}>
-              사회다양성 전형
-            </Td>
-            <Column>
               <Row>
                 <Td width={240} height={56}>
                   다문화가족 자녀

--- a/apps/admin/src/components/analysis/GradeDistribution/FinalRoundPassed/FinalRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/FinalRoundPassed/FinalRoundPassedDetail.tsx
@@ -127,7 +127,7 @@ const FinalRoundPassedDetail = () => {
               </Row>
               <Row>
                 <Td width={240} height={56}>
-                  한부모가정보호대상자
+                  한부모가정
                 </Td>
                 <Td width={80} height={56}>
                   {oneParentApplicant.max}

--- a/apps/admin/src/components/analysis/GradeDistribution/FinalRoundPassed/FinalRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/FinalRoundPassed/FinalRoundPassedDetail.tsx
@@ -156,7 +156,7 @@ const FinalRoundPassedDetail = () => {
             <Column>
               <Row>
                 <Td width={240} height={56}>
-                  다문화가정 자녀
+                  다문화가족 자녀
                 </Td>
                 <Td width={80} height={56}>
                   {multiculturalApplicant.max}

--- a/apps/admin/src/components/analysis/GradeDistribution/FinalRoundPassed/FinalRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/FinalRoundPassed/FinalRoundPassedDetail.tsx
@@ -138,7 +138,7 @@ const FinalRoundPassedDetail = () => {
               </Row>
               <Row>
                 <Td width={240} height={56}>
-                  북한이탈주민 또는 그 자녀
+                  북한이탈청소년
                 </Td>
                 <Td width={80} height={56}>
                   {fromNorthKoreaApplicant.max}

--- a/apps/admin/src/components/analysis/GradeDistribution/FirstRoundPassed/FirstRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/FirstRoundPassed/FirstRoundPassedDetail.tsx
@@ -156,7 +156,7 @@ const FirstRoundPassedDetail = () => {
             <Column>
               <Row>
                 <Td width={240} height={56}>
-                  다문화가정 자녀
+                  다문화가족 자녀
                 </Td>
                 <Td width={80} height={56}>
                   {multiculturalApplicant.max}

--- a/apps/admin/src/components/analysis/GradeDistribution/FirstRoundPassed/FirstRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/FirstRoundPassed/FirstRoundPassedDetail.tsx
@@ -127,7 +127,7 @@ const FirstRoundPassedDetail = () => {
               </Row>
               <Row>
                 <Td width={240} height={56}>
-                  한부모가정보호대상자
+                  한부모가정
                 </Td>
                 <Td width={80} height={56}>
                   {oneParentApplicant.max}

--- a/apps/admin/src/components/analysis/GradeDistribution/FirstRoundPassed/FirstRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/FirstRoundPassed/FirstRoundPassedDetail.tsx
@@ -138,7 +138,7 @@ const FirstRoundPassedDetail = () => {
               </Row>
               <Row>
                 <Td width={240} height={56}>
-                  북한이탈주민 또는 그 자녀
+                  북한이탈청소년
                 </Td>
                 <Td width={80} height={56}>
                   {fromNorthKoreaApplicant.max}

--- a/apps/admin/src/components/analysis/GradeDistribution/FirstRoundPassed/FirstRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/FirstRoundPassed/FirstRoundPassedDetail.tsx
@@ -88,7 +88,7 @@ const FirstRoundPassedDetail = () => {
             </Td>
           </Row>
           <Row>
-            <Td width={240} height={280}>
+            <Td width={240} height={224}>
               기회균등 전형
             </Td>
             <Column>
@@ -136,6 +136,13 @@ const FirstRoundPassedDetail = () => {
                   {oneParentApplicant.min}
                 </Td>
               </Row>
+            </Column>
+          </Row>
+          <Row>
+            <Td width={240} height={280}>
+              사회다양성 전형
+            </Td>
+            <Column>
               <Row>
                 <Td width={240} height={56}>
                   북한이탈청소년
@@ -147,13 +154,6 @@ const FirstRoundPassedDetail = () => {
                   {fromNorthKoreaApplicant.min}
                 </Td>
               </Row>
-            </Column>
-          </Row>
-          <Row>
-            <Td width={240} height={224}>
-              사회다양성 전형
-            </Td>
-            <Column>
               <Row>
                 <Td width={240} height={56}>
                   다문화가족 자녀

--- a/apps/admin/src/components/analysis/GradeDistribution/SecondRoundPassed/SecondRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/SecondRoundPassed/SecondRoundPassedDetail.tsx
@@ -156,7 +156,7 @@ const SecondRoundPassedDetail = () => {
             <Column>
               <Row>
                 <Td width={240} height={56}>
-                  다문화가정 자녀
+                  다문화가족 자녀
                 </Td>
                 <Td width={80} height={56}>
                   {multiculturalApplicant.max}

--- a/apps/admin/src/components/analysis/GradeDistribution/SecondRoundPassed/SecondRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/SecondRoundPassed/SecondRoundPassedDetail.tsx
@@ -88,7 +88,7 @@ const SecondRoundPassedDetail = () => {
             </Td>
           </Row>
           <Row>
-            <Td width={240} height={280}>
+            <Td width={240} height={224}>
               기회균등 전형
             </Td>
             <Column>
@@ -136,6 +136,13 @@ const SecondRoundPassedDetail = () => {
                   {oneParentApplicant.min}
                 </Td>
               </Row>
+            </Column>
+          </Row>
+          <Row>
+            <Td width={240} height={280}>
+              사회다양성 전형
+            </Td>
+            <Column>
               <Row>
                 <Td width={240} height={56}>
                   북한이탈청소년
@@ -147,13 +154,6 @@ const SecondRoundPassedDetail = () => {
                   {fromNorthKoreaApplicant.min}
                 </Td>
               </Row>
-            </Column>
-          </Row>
-          <Row>
-            <Td width={240} height={224}>
-              사회다양성 전형
-            </Td>
-            <Column>
               <Row>
                 <Td width={240} height={56}>
                   다문화가족 자녀

--- a/apps/admin/src/components/analysis/GradeDistribution/SecondRoundPassed/SecondRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/SecondRoundPassed/SecondRoundPassedDetail.tsx
@@ -127,7 +127,7 @@ const SecondRoundPassedDetail = () => {
               </Row>
               <Row>
                 <Td width={240} height={56}>
-                  한부모가정보호대상자
+                  한부모가정
                 </Td>
                 <Td width={80} height={56}>
                   {oneParentApplicant.max}

--- a/apps/admin/src/components/analysis/GradeDistribution/SecondRoundPassed/SecondRoundPassedDetail.tsx
+++ b/apps/admin/src/components/analysis/GradeDistribution/SecondRoundPassed/SecondRoundPassedDetail.tsx
@@ -138,7 +138,7 @@ const SecondRoundPassedDetail = () => {
               </Row>
               <Row>
                 <Td width={240} height={56}>
-                  북한이탈주민 또는 그 자녀
+                  북한이탈청소년
                 </Td>
                 <Td width={80} height={56}>
                   {fromNorthKoreaApplicant.max}

--- a/apps/admin/src/components/analysis/NumberOfApplicants/NumberOfApplicantsDetail/NumberOfApplicantsDetail.tsx
+++ b/apps/admin/src/components/analysis/NumberOfApplicants/NumberOfApplicantsDetail/NumberOfApplicantsDetail.tsx
@@ -71,8 +71,8 @@ const NumberOfApplicants = () => {
             </Td>
           </Row>
           <Row>
-            <Td width={240} height={280}>
-              기호균등 전형
+            <Td width={240} height={224}>
+              기회균등 전형
             </Td>
             <Column>
               <Row>
@@ -101,30 +101,30 @@ const NumberOfApplicants = () => {
               </Row>
               <Row>
                 <Td width={240} height={56}>
-                  한부모가정보호대상자
+                  한부모가정
                 </Td>
                 <Td width={80} height={56}>
                   {oneParentApplicant}
                 </Td>
               </Row>
-              <Row>
-                <Td width={240} height={56}>
-                  북한이탈주민 또는 그 자녀
-                </Td>
-                <Td width={80} height={56}>
-                  {fromNorthKoreaApplicant}
-                </Td>
-              </Row>
             </Column>
           </Row>
           <Row>
-            <Td width={240} height={224}>
+            <Td width={240} height={280}>
               사회다양성 전형
             </Td>
             <Column>
               <Row>
                 <Td width={240} height={56}>
-                  다문화가정 자녀
+                  북한이탈청소년
+                </Td>
+                <Td width={80} height={56}>
+                  {fromNorthKoreaApplicant}
+                </Td>
+              </Row>
+              <Row>
+                <Td width={240} height={56}>
+                  다문화가족 자녀
                 </Td>
                 <Td width={80} height={56}>
                   {multiculturalApplicant}
@@ -148,7 +148,7 @@ const NumberOfApplicants = () => {
               </Row>
               <Row>
                 <Td width={240} height={56}>
-                  농어촌지역출신자
+                  농어촌 지역 출신자
                 </Td>
                 <Td width={80} height={56}>
                   {farmingAndFishingApplicant}

--- a/apps/admin/src/components/analysis/NumberOfApplicants/NumberOfApplicantsDetail/NumberOfApplicantsDetail.tsx
+++ b/apps/admin/src/components/analysis/NumberOfApplicants/NumberOfApplicantsDetail/NumberOfApplicantsDetail.tsx
@@ -148,7 +148,7 @@ const NumberOfApplicants = () => {
               </Row>
               <Row>
                 <Td width={240} height={56}>
-                  농어촌 지역 출신자
+                  농어촌지역출신자
                 </Td>
                 <Td width={80} height={56}>
                   {farmingAndFishingApplicant}

--- a/apps/admin/src/constants/main/constants.ts
+++ b/apps/admin/src/constants/main/constants.ts
@@ -9,7 +9,7 @@ export const FORM_TYPE: Record<FormType, string> = {
   NATIONAL_VETERANS: '국가보훈자녀',
   ONE_PARENT: '한부모가정',
   FROM_NORTH_KOREA: '북한이탈주민',
-  MULTICULTURAL: '다문화가정',
+  MULTICULTURAL: '다문화가족 자녀',
   TEEN_HOUSEHOLDER: '소년소녀가장',
   MULTI_CHILDREN: '다자녀가정자녀',
   FARMING_AND_FISHING: '농어촌지역출신자',

--- a/apps/admin/src/constants/main/constants.ts
+++ b/apps/admin/src/constants/main/constants.ts
@@ -8,7 +8,7 @@ export const FORM_TYPE: Record<FormType, string> = {
   NEAR_POVERTY: '차상위계층',
   NATIONAL_VETERANS: '국가보훈자녀',
   ONE_PARENT: '한부모가정',
-  FROM_NORTH_KOREA: '북한이탈주민',
+  FROM_NORTH_KOREA: '북한이탈청소년',
   MULTICULTURAL: '다문화가족 자녀',
   TEEN_HOUSEHOLDER: '소년소녀가장',
   MULTI_CHILDREN: '다자녀가정자녀',

--- a/apps/user/src/app/form/전형선택/전형선택.tsx
+++ b/apps/user/src/app/form/전형선택/전형선택.tsx
@@ -82,7 +82,7 @@ const 전형선택 = () => {
               </Td>
             </Row>
             <Row>
-              <Td width="calc(736px/3)" height={280}>
+              <Td width="calc(736px/3)" height={224}>
                 기회균등 전형
               </Td>
               <Column>
@@ -127,7 +127,7 @@ const 전형선택 = () => {
                 </Row>
                 <Row>
                   <Td width="calc(736px/3)" height={56}>
-                    한부모가정보호대상자
+                    한부모가정
                   </Td>
                   <Td width={80} height={56}>
                     <Radio
@@ -138,9 +138,16 @@ const 전형선택 = () => {
                     />
                   </Td>
                 </Row>
+              </Column>
+            </Row>
+            <Row>
+              <Td width="calc(736px/3)" height={280}>
+                사회다양성 전형
+              </Td>
+              <Column>
                 <Row>
                   <Td width="calc(736px/3)" height={56}>
-                    북한이탈주민 또는 그 자녀
+                    북한이탈청소년
                   </Td>
                   <Td width={80} height={56}>
                     <Radio
@@ -151,16 +158,9 @@ const 전형선택 = () => {
                     />
                   </Td>
                 </Row>
-              </Column>
-            </Row>
-            <Row>
-              <Td width="calc(736px/3)" height={224}>
-                사회다양성 전형
-              </Td>
-              <Column>
                 <Row>
                   <Td width="calc(736px/3)" height={56}>
-                    다문화가정 자녀
+                    다문화가족 자녀
                   </Td>
                   <Td width={80} height={56}>
                     <Radio


### PR DESCRIPTION
## 📄 Summary

> 2025학년도 입학 전형 요강에 따라 이름을 변경 했습니다.
> 북한이탈청소년이 기회균등전형에서 사회다양성전형으로 변경되어 반영 하였습니다.

<br>

## 🔨 Tasks

- 전형별 명칭 변경 
- 북한이탈청소년 전형을 사회다양성 전형으로 변경

<br>

## 🙋🏻 More
![image](https://github.com/Bamdoliro/marururu/assets/127070837/a7edde3e-0a17-437f-a0be-c665872a8249)
![image](https://github.com/Bamdoliro/marururu/assets/127070837/8aa6e1b1-9f04-4a29-8853-5787c4dbaeca)
