### PR TITLE
fix(user): 수학 성취도 없으면 C 성적으로 산출되도록 수정

### DIFF
--- a/apps/user/src/hooks/useGradeCaculation.ts
+++ b/apps/user/src/hooks/useGradeCaculation.ts
@@ -41,11 +41,14 @@ const useGradeCalculation = () => {
       const achievementLevel = subject[achievementLevelKey];
       const subjectName = subject.subjectName;
       if (
-        (subjectName === '국어' || subjectName === '수학' || subjectName === '영어') &&
+        (subjectName === '국어' || subjectName === '영어') &&
         achievementLevel === null
       ) {
         hyphenLength += 1;
         return acc + AchievementScore['C'];
+      } else if (subjectName === '수학' && achievementLevel === null) {
+        hyphenLength += 1;
+        return acc + AchievementScore['C'] * 2;
       }
       if (subjectName === '수학' && achievementLevel !== null) {
         return acc + AchievementScore[achievementLevel] * 2;


### PR DESCRIPTION
## 📄 Summary

> 기존에 국어,수학,영어의 성취도가 없을 시 C 성적으로 산출되도록 해야하여 이를 수정하였습니다. 하지만 테스트 도중 수학은 *2해주어야 한다는 예외 처리를 하지 않아 잘 못 계산 되고 있었습니다. 그래서 이번에 예외를 추가하여 수학 성취도가 없으면 *2를 주도록 수정하였습니다.

<br>

## 🔨 Tasks

- 수학에 대한 예외 처리 코드 추가

<br>

## 🙋🏻 More
