### PR TITLE
fix(user): 출신학교및학력의 조건이 맞지 않은데 다음으로 넘어갈려고 할 시 에러메시지 띄우도록 수정

### DIFF
--- a/apps/user/src/app/form/출신학교및학력/출신학교및학력.tsx
+++ b/apps/user/src/app/form/출신학교및학력/출신학교및학력.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FindSchoolModal, FormController } from '@/components/form';
 import { FormLayout } from '@/layouts';
 import { useFormValueStore, useSetFormStore } from '@/store';
@@ -8,12 +8,66 @@ import { useOverlay } from '@toss/use-overlay';
 import styled from 'styled-components';
 import { useCTAButton, useInput } from './출신학교및학력.hooks';
 
+interface Props {
+  graduationType: string;
+}
+
 const 출신학교및학력 = () => {
   const overlay = useOverlay();
   const form = useFormValueStore();
   const setForm = useSetFormStore();
   const { handle출신학교및학력Change } = useInput();
   const { handleMoveNextStep, handleMovePreviousStep } = useCTAButton();
+
+  const [isNextClicked, setIsNextClicked] = useState(false);
+  const [isSchoolNameError, setIsSchoolNameError] = useState(false);
+  const [isSchoolAddressError, setIsSchoolAddressError] = useState(false);
+  const [isSchoolLocationError, setIsSchoolLocationError] = useState(false);
+  const [isSchoolCodeError, setIsSchoolCodeError] = useState(false);
+  const [isTeacherPhoneNumberError, setIsTeacherPhoneNumberError] = useState(false);
+  const [isTeacherNameError, setIsTeacherNameError] = useState(false);
+  const [isTeacherMobilePhoneNumberError, setIsTeacherMobilePhoneNumberError] =
+    useState(false);
+  const [isGraduationYeareError, setIsGraduationYearError] = useState(false);
+
+  const validateForm = () => {
+    const {
+      graduationType,
+      schoolName,
+      schoolAddress,
+      schoolLocation,
+      schoolCode,
+      teacherPhoneNumber,
+      teacherName,
+      teacherMobilePhoneNumber,
+      graduationYear,
+    } = form.education;
+
+    if (graduationType === 'QUALIFICATION_EXAMINATION') {
+      return graduationYear.length === 4;
+    } else {
+      const schoolNameValid = (schoolName ?? '').length === null;
+      const schoolAddressValid = (schoolAddress ?? '').length === null;
+      const schoolLocationValid = (schoolLocation ?? '').length === null;
+      const schoolCodeValid = (schoolCode ?? '').length === null;
+      const teacherPhoneNumberValid = (teacherPhoneNumber ?? '').length === null;
+      const teacherNameValid = (teacherName ?? '').length === null;
+      const teacherMobilePhoneNumberValid =
+        (teacherMobilePhoneNumber ?? '').length === null;
+      const graduationYearValid = (graduationYear ?? '').length === 4;
+
+      return (
+        schoolNameValid &&
+        schoolAddressValid &&
+        schoolLocationValid &&
+        schoolCodeValid &&
+        teacherPhoneNumberValid &&
+        teacherNameValid &&
+        teacherMobilePhoneNumberValid &&
+        graduationYearValid
+      );
+    }
+  };
 
   useEffect(() => {
     if (form.education.graduationType === 'QUALIFICATION_EXAMINATION') {
@@ -39,6 +93,80 @@ const 출신학교및학력 = () => {
     ));
   };
 
+  const handleNextClick = () => {
+    setIsNextClicked(true);
+
+    const isValid = validateForm();
+
+    setIsSchoolNameError(
+      (form.education.schoolName ?? '').length === 0 ||
+        ((form.education.schoolName ?? '').length >= 25 &&
+          (form.education.schoolName ?? '').length < 0)
+    );
+    setIsSchoolAddressError(
+      (form.education.schoolAddress ?? '').length === 0 ||
+        ((form.education.schoolAddress ?? '').length > 40 &&
+          (form.education.schoolName ?? '').length < 0)
+    );
+    setIsSchoolLocationError(
+      (form.education.schoolLocation ?? '').length === 0 ||
+        ((form.education.schoolLocation ?? '').length > 20 &&
+          (form.education.schoolName ?? '').length < 0)
+    );
+    setIsSchoolCodeError((form.education.schoolCode ?? '').length !== 7);
+    setIsTeacherPhoneNumberError(
+      (form.education.teacherPhoneNumber ?? '').length === 0 ||
+        (form.education.teacherPhoneNumber ?? '').length !== 11
+    );
+    setIsTeacherNameError(
+      (form.education.teacherName ?? '').length === 0 ||
+        ((form.education.teacherName ?? '').length > 20 &&
+          (form.education.schoolName ?? '').length < 0)
+    );
+    setIsTeacherMobilePhoneNumberError(
+      (form.education.teacherMobilePhoneNumber ?? '').length !== 11
+    );
+    setIsGraduationYearError((form.education.graduationYear ?? '').length !== 4);
+
+    if (isValid) {
+      handleMoveNextStep();
+    }
+  };
+
+  useEffect(() => {
+    if (isNextClicked) {
+      setIsSchoolNameError(
+        (form.education.schoolName ?? '').length === 0 ||
+          ((form.education.schoolName ?? '').length >= 25 &&
+            (form.education.schoolName ?? '').length < 0)
+      );
+      setIsSchoolAddressError(
+        (form.education.schoolAddress ?? '').length === 0 ||
+          ((form.education.schoolAddress ?? '').length > 40 &&
+            (form.education.schoolName ?? '').length < 0)
+      );
+      setIsSchoolLocationError(
+        (form.education.schoolLocation ?? '').length === 0 ||
+          ((form.education.schoolLocation ?? '').length > 20 &&
+            (form.education.schoolName ?? '').length < 0)
+      );
+      setIsSchoolCodeError((form.education.schoolCode ?? '').length !== 7);
+      setIsTeacherPhoneNumberError(
+        (form.education.teacherPhoneNumber ?? '').length === 0 ||
+          (form.education.teacherPhoneNumber ?? '').length !== 11
+      );
+      setIsTeacherNameError(
+        (form.education.teacherName ?? '').length === 0 ||
+          ((form.education.teacherName ?? '').length > 20 &&
+            (form.education.schoolName ?? '').length < 0)
+      );
+      setIsTeacherMobilePhoneNumberError(
+        (form.education.teacherMobilePhoneNumber ?? '').length !== 11
+      );
+      setIsGraduationYearError((form.education.graduationYear ?? '').length !== 4);
+    }
+  }, [form, isNextClicked]);
+
   return (
     <FormLayout title="출신학교 및 학력">
       <Styled출신학교및학력>
@@ -63,10 +191,8 @@ const 출신학교및학력 = () => {
               onClick={openFindSchoolModal}
               placeholder="검색 버튼을 눌러 학교를 검색하세요."
               readOnly
-              isError={
-                !!form.education.schoolName && form.education.schoolName.length > 20
-              }
-              errorMessage="20자 이하여야 합니다."
+              isError={isSchoolNameError}
+              errorMessage=""
             />
           )}
           {form.education.graduationType !== 'QUALIFICATION_EXAMINATION' && (
@@ -78,10 +204,8 @@ const 출신학교및학력 = () => {
               readOnly
               value={form.education.schoolAddress ?? ''}
               onChange={handle출신학교및학력Change}
-              isError={
-                !!form.education.schoolAddress && form.education.schoolAddress.length > 40
-              }
-              errorMessage="40자 이하여야 합니다."
+              isError={isSchoolAddressError}
+              errorMessage=""
             />
           )}
         </Row>
@@ -101,11 +225,8 @@ const 출신학교및학력 = () => {
             }
             value={form.education.graduationYear}
             onChange={handle출신학교및학력Change}
-            isError={
-              !!form.education.graduationYear &&
-              form.education.graduationYear.length !== 4
-            }
-            errorMessage="4자여야 합니다."
+            isError={isGraduationYeareError}
+            errorMessage=""
           />
           {form.education.graduationType !== 'QUALIFICATION_EXAMINATION' && (
             <Input
@@ -113,11 +234,8 @@ const 출신학교및학력 = () => {
               label="지역"
               placeholder="학교를 선택하면 자동완성됩니다."
               readOnly
-              isError={
-                !!form.education.schoolLocation &&
-                form.education.schoolLocation.length > 20
-              }
-              errorMessage="20자여야 합니다."
+              isError={isSchoolLocationError}
+              errorMessage=""
               width="100%"
               value={form.education.schoolLocation ?? ''}
               onChange={handle출신학교및학력Change}
@@ -134,10 +252,8 @@ const 출신학교및학력 = () => {
               width="100%"
               value={form.education.schoolCode ?? ''}
               onChange={handle출신학교및학력Change}
-              isError={
-                !!form.education.schoolCode && form.education.schoolCode.length !== 7
-              }
-              errorMessage="7자여야 합니다."
+              isError={isSchoolCodeError}
+              errorMessage=""
             />
           )}
           {form.education.graduationType !== 'QUALIFICATION_EXAMINATION' && (
@@ -148,11 +264,8 @@ const 출신학교및학력 = () => {
               width="100%"
               value={form.education.teacherPhoneNumber ?? ''}
               onChange={handle출신학교및학력Change}
-              isError={
-                !!form.education.teacherPhoneNumber &&
-                form.education.teacherPhoneNumber.length > 11
-              }
-              errorMessage="11자 이하여야 합니다."
+              isError={isTeacherPhoneNumberError}
+              errorMessage=""
             />
           )}
         </Row>
@@ -165,10 +278,8 @@ const 출신학교및학력 = () => {
               width="100%"
               value={form.education.teacherName ?? ''}
               onChange={handle출신학교및학력Change}
-              isError={
-                !!form.education.teacherName && form.education.teacherName.length > 20
-              }
-              errorMessage="20자 이하여야 합니다."
+              isError={isTeacherNameError}
+              errorMessage=""
             />
           )}
           {form.education.graduationType !== 'QUALIFICATION_EXAMINATION' && (
@@ -179,20 +290,19 @@ const 출신학교및학력 = () => {
               width="100%"
               value={form.education.teacherMobilePhoneNumber ?? ''}
               onChange={handle출신학교및학력Change}
-              isError={
-                !!form.education.teacherMobilePhoneNumber &&
-                form.education.teacherMobilePhoneNumber.length > 11
-              }
-              errorMessage="11자 이하여야 합니다."
+              isError={isTeacherMobilePhoneNumberError}
+              errorMessage=""
             />
           )}
         </Row>
       </Styled출신학교및학력>
-      <FormController
-        onPrevious={handleMovePreviousStep}
-        onNext={handleMoveNextStep}
-        step="출신학교및학력"
-      />
+      <StyledFormController graduationType={form.education.graduationType}>
+        <FormController
+          onPrevious={handleMovePreviousStep}
+          onNext={handleNextClick}
+          step="출신학교및학력"
+        />
+      </StyledFormController>
     </FormLayout>
   );
 };
@@ -204,4 +314,9 @@ const Styled출신학교및학력 = styled.div`
   gap: 30px;
   width: 100%;
   height: 100%;
+`;
+
+const StyledFormController = styled.div<Props>`
+  margin-top: ${(props) =>
+    props.graduationType === 'QUALIFICATION_EXAMINATION' ? '290.391px' : '0px'};
 `;


### PR DESCRIPTION
## 📄 Summary

> 교무부 시연 당시 원서작성할때 페이지마다 빈칸이 있으면 넘어가지 않고 입력되지 않은 부분을 알려주라는 요청으로 수정하게되었습니다.
이번에 고입검정 입력 방법을 바꾸면서 입력 조건을 충족해야지 넘어가도록 수정하였습니다.

<br>

## 🔨 Tasks

- 출신학교및학력의 조건을 추가하여 맞지 않으면 다음을 누르면 알려주고 맞으면 넘어가도록 수정

<br>

## 🙋🏻 More
