### PR TITLE
fix(user): 고입검정일 경우 2개, 아닐 경우 9개로 표시되도록 수정

### DIFF
--- a/apps/user/src/app/form/초안작성완료/초안작성완료.hooks.ts
+++ b/apps/user/src/app/form/초안작성완료/초안작성완료.hooks.ts
@@ -50,7 +50,13 @@ const useFilledParentFieldsCount = (parent: Form['parent']) =>
 const useFilledEducationFieldsCount = (education: Form['education']) => {
   return Object.entries(education).reduce((acc, [key, value]) => {
     if (education.graduationType === 'QUALIFICATION_EXAMINATION') {
-      return acc + 1;
+      switch (key) {
+        case 'graduationType':
+        case 'graduationYear':
+          return acc + 1;
+        default:
+          return acc;
+      }
     }
 
     if (!value) {
@@ -59,6 +65,7 @@ const useFilledEducationFieldsCount = (education: Form['education']) => {
 
     switch (key) {
       case 'schoolName':
+        return acc + Number(value.length <= 30);
       case 'schoolLocation':
       case 'schoolAddress':
       case 'teacherName':
@@ -98,7 +105,8 @@ export const useCheckFilledForm = () => {
     if (
       filledApplicantFieldsCount === 5 &&
       filledParentFieldsCount === 6 &&
-      filledEducationFieldsCount === 9 &&
+      filledEducationFieldsCount ===
+        (form.education.graduationType === 'QUALIFICATION_EXAMINATION' ? 2 : 9) &&
       filledTypeFieldCount === 1 &&
       filledDocumentFieldsCount === 2
     ) {

--- a/apps/user/src/app/form/출신학교및학력/출신학교및학력.tsx
+++ b/apps/user/src/app/form/출신학교및학력/출신학교및학력.tsx
@@ -28,7 +28,7 @@ const 출신학교및학력 = () => {
   const [isTeacherNameError, setIsTeacherNameError] = useState(false);
   const [isTeacherMobilePhoneNumberError, setIsTeacherMobilePhoneNumberError] =
     useState(false);
-  const [isGraduationYeareError, setIsGraduationYearError] = useState(false);
+  const [isGraduationYearError, setIsGraduationYearError] = useState(false);
 
   const validateForm = () => {
     const {
@@ -46,14 +46,18 @@ const 출신학교및학력 = () => {
     if (graduationType === 'QUALIFICATION_EXAMINATION') {
       return graduationYear.length === 4;
     } else {
-      const schoolNameValid = (schoolName ?? '').length === null;
-      const schoolAddressValid = (schoolAddress ?? '').length === null;
-      const schoolLocationValid = (schoolLocation ?? '').length === null;
-      const schoolCodeValid = (schoolCode ?? '').length === null;
-      const teacherPhoneNumberValid = (teacherPhoneNumber ?? '').length === null;
-      const teacherNameValid = (teacherName ?? '').length === null;
+      const schoolNameValid =
+        (schoolName ?? '').length > 0 && (schoolName ?? '').length < 30;
+      const schoolAddressValid =
+        (schoolAddress ?? '').length > 0 && (schoolAddress ?? '').length < 40;
+      const schoolLocationValid =
+        (schoolLocation ?? '').length > 0 && (schoolLocation ?? '').length < 10;
+      const schoolCodeValid = (schoolCode ?? '').length === 7;
+      const teacherPhoneNumberValid = (teacherPhoneNumber ?? '').length === 11;
+      const teacherNameValid =
+        (teacherName ?? '').length > 0 && (teacherName ?? '').length < 20;
       const teacherMobilePhoneNumberValid =
-        (teacherMobilePhoneNumber ?? '').length === null;
+        (teacherMobilePhoneNumber ?? '').length === 11;
       const graduationYearValid = (graduationYear ?? '').length === 4;
 
       return (
@@ -99,32 +103,36 @@ const 출신학교및학력 = () => {
     const isValid = validateForm();
 
     setIsSchoolNameError(
-      (form.education.schoolName ?? '').length === 0 ||
-        ((form.education.schoolName ?? '').length >= 25 &&
-          (form.education.schoolName ?? '').length < 0)
+      form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+        ((form.education.schoolName ?? '').length === 0 ||
+          (form.education.schoolName ?? '').length >= 30)
     );
     setIsSchoolAddressError(
-      (form.education.schoolAddress ?? '').length === 0 ||
-        ((form.education.schoolAddress ?? '').length > 40 &&
-          (form.education.schoolName ?? '').length < 0)
+      form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+        ((form.education.schoolAddress ?? '').length === 0 ||
+          (form.education.schoolAddress ?? '').length >= 40)
     );
     setIsSchoolLocationError(
-      (form.education.schoolLocation ?? '').length === 0 ||
-        ((form.education.schoolLocation ?? '').length > 20 &&
-          (form.education.schoolName ?? '').length < 0)
+      form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+        ((form.education.schoolLocation ?? '').length === 0 ||
+          (form.education.schoolLocation ?? '').length >= 10)
     );
-    setIsSchoolCodeError((form.education.schoolCode ?? '').length !== 7);
+    setIsSchoolCodeError(
+      form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+        (form.education.schoolCode ?? '').length !== 7
+    );
     setIsTeacherPhoneNumberError(
-      (form.education.teacherPhoneNumber ?? '').length === 0 ||
+      form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
         (form.education.teacherPhoneNumber ?? '').length !== 11
     );
     setIsTeacherNameError(
-      (form.education.teacherName ?? '').length === 0 ||
-        ((form.education.teacherName ?? '').length > 20 &&
-          (form.education.schoolName ?? '').length < 0)
+      form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+        ((form.education.teacherName ?? '').length === 0 ||
+          (form.education.teacherName ?? '').length >= 20)
     );
     setIsTeacherMobilePhoneNumberError(
-      (form.education.teacherMobilePhoneNumber ?? '').length !== 11
+      form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+        (form.education.teacherMobilePhoneNumber ?? '').length !== 11
     );
     setIsGraduationYearError((form.education.graduationYear ?? '').length !== 4);
 
@@ -136,32 +144,36 @@ const 출신학교및학력 = () => {
   useEffect(() => {
     if (isNextClicked) {
       setIsSchoolNameError(
-        (form.education.schoolName ?? '').length === 0 ||
-          ((form.education.schoolName ?? '').length >= 25 &&
-            (form.education.schoolName ?? '').length < 0)
+        form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+          ((form.education.schoolName ?? '').length === 0 ||
+            (form.education.schoolName ?? '').length >= 30)
       );
       setIsSchoolAddressError(
-        (form.education.schoolAddress ?? '').length === 0 ||
-          ((form.education.schoolAddress ?? '').length > 40 &&
-            (form.education.schoolName ?? '').length < 0)
+        form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+          ((form.education.schoolAddress ?? '').length === 0 ||
+            (form.education.schoolAddress ?? '').length >= 40)
       );
       setIsSchoolLocationError(
-        (form.education.schoolLocation ?? '').length === 0 ||
-          ((form.education.schoolLocation ?? '').length > 20 &&
-            (form.education.schoolName ?? '').length < 0)
+        form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+          ((form.education.schoolLocation ?? '').length === 0 ||
+            (form.education.schoolLocation ?? '').length >= 10)
       );
-      setIsSchoolCodeError((form.education.schoolCode ?? '').length !== 7);
+      setIsSchoolCodeError(
+        form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+          (form.education.schoolCode ?? '').length !== 7
+      );
       setIsTeacherPhoneNumberError(
-        (form.education.teacherPhoneNumber ?? '').length === 0 ||
+        form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
           (form.education.teacherPhoneNumber ?? '').length !== 11
       );
       setIsTeacherNameError(
-        (form.education.teacherName ?? '').length === 0 ||
-          ((form.education.teacherName ?? '').length > 20 &&
-            (form.education.schoolName ?? '').length < 0)
+        form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+          ((form.education.teacherName ?? '').length === 0 ||
+            (form.education.teacherName ?? '').length >= 20)
       );
       setIsTeacherMobilePhoneNumberError(
-        (form.education.teacherMobilePhoneNumber ?? '').length !== 11
+        form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
+          (form.education.teacherMobilePhoneNumber ?? '').length !== 11
       );
       setIsGraduationYearError((form.education.graduationYear ?? '').length !== 4);
     }
@@ -225,7 +237,7 @@ const 출신학교및학력 = () => {
             }
             value={form.education.graduationYear}
             onChange={handle출신학교및학력Change}
-            isError={isGraduationYeareError}
+            isError={isGraduationYearError}
             errorMessage=""
           />
           {form.education.graduationType !== 'QUALIFICATION_EXAMINATION' && (

--- a/apps/user/src/components/form/CheckFormCompleteBox/CheckFormCompleteBox.tsx
+++ b/apps/user/src/components/form/CheckFormCompleteBox/CheckFormCompleteBox.tsx
@@ -1,4 +1,4 @@
-import { useSetFormStepStore } from '@/store';
+import { useFormValueStore, useSetFormStepStore } from '@/store';
 import { styled } from 'styled-components';
 import CheckFormComplete from './CheckFormComplete/CheckFormComplete';
 
@@ -18,6 +18,7 @@ const CheckFormCompleteBox = ({
   documentFilledCount,
 }: Props) => {
   const setFormStep = useSetFormStepStore();
+  const form = useFormValueStore();
 
   return (
     <StyledCheckFormCompleteBox>
@@ -36,7 +37,9 @@ const CheckFormCompleteBox = ({
       <CheckFormComplete
         onClick={() => setFormStep('출신학교및학력')}
         formStep="출신학교 및 학력"
-        maxCompleteOfNumber={9}
+        maxCompleteOfNumber={
+          form.education.graduationType === 'QUALIFICATION_EXAMINATION' ? +'2' : 9
+        }
         completeOfNumber={educationFilledCount}
       />
       <CheckFormComplete


### PR DESCRIPTION
## 📄 Summary

> 출신학교및학력이 졸업, 졸업예정일때 조건이 충족하더라도 넘어가지지 않는 문제가 있음. 또한 고입검정은 2가지만 입력하는데 초안제출할때는 9개라고 나와 유저에게 혼란을 줄 수 있어 이를 수정해야 했습니다.



<br>

## 🔨 Tasks

- 고입검정일 경우 2개, 아닐경우 9개로 초안제출에 표시되도록 수정
- 유효성 검사 조건 수정

<br>

## 🙋🏻 More
