### PR TITLE
feat(user): 사진 규격보다 크면 규격만큼 자르는 기능 개발

### DIFF
--- a/apps/user/package.json
+++ b/apps/user/package.json
@@ -33,9 +33,9 @@
     "typescript": "5.1.3"
   },
   "dependencies": {
+    "@maru/design-token": "workspace:*",
     "@maru/hooks": "workspace:*",
     "@maru/icon": "workspace:*",
-    "@maru/design-token": "workspace:*",
     "@maru/ui": "workspace:*",
     "@maru/utils": "workspace:*",
     "@suspensive/react": "^1.18.1",
@@ -50,6 +50,7 @@
     "react": "18.2.0",
     "react-daum-postcode": "^3.1.3",
     "react-dom": "18.2.0",
+    "react-easy-crop": "^5.0.7",
     "recoil": "^0.7.7",
     "styled-components": "^6.0.3"
   }

--- a/apps/user/src/components/form/CropImageModal/CropImageModal.tsx
+++ b/apps/user/src/components/form/CropImageModal/CropImageModal.tsx
@@ -1,0 +1,100 @@
+import React, { useState, useCallback } from 'react';
+import { color } from '@maru/design-token';
+import { Button, Column, Text } from '@maru/ui';
+import { flex } from '@maru/utils';
+import styled from 'styled-components';
+import type { Area } from 'react-easy-crop';
+import Cropper from 'react-easy-crop';
+import { getCroppedImg } from '@/utils';
+
+interface Props {
+  isOpen: boolean;
+  imageSrc: string;
+  onClose: () => void;
+  onCropComplete: (croppedImage: Blob) => void;
+}
+
+const CropImageModal = ({ isOpen, imageSrc, onClose, onCropComplete }: Props) => {
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [croppedArea, setCroppedArea] = useState<Area | null>(null);
+
+  const onCropCompleteInternal = useCallback(
+    (croppedArea: Area, croppedAreaPixels: Area) => {
+      setCroppedArea(croppedAreaPixels);
+    },
+    []
+  );
+
+  const applyCrop = useCallback(async () => {
+    if (!croppedArea) return;
+    const croppedImage = await getCroppedImg(imageSrc, croppedArea, 117, 156);
+
+    const response = await fetch(croppedImage as string);
+    const blob = await response.blob();
+
+    onCropComplete(blob);
+    onClose();
+  }, [imageSrc, croppedArea, onCropComplete, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <BlurBackground>
+      <ModalContainer>
+        <Column alignItems="center" gap={16}>
+          <CropImageModalStyle>
+            <Cropper
+              image={imageSrc}
+              crop={crop}
+              aspect={117 / 156}
+              onCropChange={setCrop}
+              onCropComplete={onCropCompleteInternal}
+              style={{
+                containerStyle: { width: '100%', height: '100%', position: 'relative' },
+              }}
+            />
+          </CropImageModalStyle>
+          <Button onClick={applyCrop}>
+            <Text fontType="btn1" color={color.white}>
+              사진 자르기 적용
+            </Text>
+          </Button>
+        </Column>
+      </ModalContainer>
+    </BlurBackground>
+  );
+};
+
+export default CropImageModal;
+
+const BlurBackground = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+`;
+
+const ModalContainer = styled.div`
+  padding: 20px;
+  border-radius: 10px;
+  max-width: 466px;
+  width: 100%;
+  text-align: center;
+  height: 357px;
+`;
+
+const CropImageModalStyle = styled.div`
+  ${flex({ flexDirection: 'column', justifyContent: 'center' })}
+  width: 100%;
+  height: 400px;
+  border-radius: 6px;
+  border: 3px solid ${color.gray300};
+  position: relative;
+  overflow: hidden;
+`;

--- a/apps/user/src/components/form/CropImageModal/CropImageModal.tsx
+++ b/apps/user/src/components/form/CropImageModal/CropImageModal.tsx
@@ -8,15 +8,17 @@ import Cropper from 'react-easy-crop';
 import { getCropImg } from '@/utils';
 
 interface Props {
+  zoom: number;
   isOpen: boolean;
   imageSrc: string;
   onClose: () => void;
   onCropComplete: (croppedImage: Blob) => void;
 }
 
-const CropImageModal = ({ isOpen, imageSrc, onClose, onCropComplete }: Props) => {
+const CropImageModal = ({ zoom, isOpen, imageSrc, onClose, onCropComplete }: Props) => {
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [cropArea, setCropArea] = useState<Area | null>(null);
+  const [currentZoom, setCurrentZoom] = useState(zoom);
 
   const onCropCompleteInternal = useCallback(
     (cropArea: Area, croppedAreaPixels: Area) => {
@@ -36,6 +38,10 @@ const CropImageModal = ({ isOpen, imageSrc, onClose, onCropComplete }: Props) =>
     onClose();
   }, [imageSrc, cropArea, onCropComplete, onClose]);
 
+  const handleZoomChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrentZoom(Number(e.target.value));
+  };
+
   if (!isOpen) return null;
 
   return (
@@ -46,14 +52,26 @@ const CropImageModal = ({ isOpen, imageSrc, onClose, onCropComplete }: Props) =>
             <Cropper
               image={imageSrc}
               crop={crop}
+              zoom={currentZoom}
               aspect={117 / 156}
               onCropChange={setCrop}
               onCropComplete={onCropCompleteInternal}
+              onZoomChange={setCurrentZoom}
               style={{
                 containerStyle: { width: '100%', height: '100%', position: 'relative' },
               }}
             />
           </CropImageModalStyle>
+          <ZoomBoxStyle>
+            <InputStyle
+              type="range"
+              min="1"
+              max="3"
+              step="0.1"
+              value={currentZoom}
+              onChange={handleZoomChange}
+            />
+          </ZoomBoxStyle>
           <Button onClick={handleApplyCrop}>
             <Text fontType="btn1" color={color.white}>
               사진 자르기 적용
@@ -69,7 +87,6 @@ export default CropImageModal;
 
 const BlurBackground = styled.div`
   display: flex;
-  align-items: center;
   justify-content: center;
   position: fixed;
   top: 0;
@@ -81,9 +98,10 @@ const BlurBackground = styled.div`
 `;
 
 const ModalContainer = styled.div`
+  margin-top: 10%;
   padding: 20px;
   border-radius: 10px;
-  max-width: 466px;
+  max-width: 468px;
   width: 100%;
   text-align: center;
   height: 357px;
@@ -97,4 +115,38 @@ const CropImageModalStyle = styled.div`
   border: 3px solid ${color.gray300};
   position: relative;
   overflow: hidden;
+`;
+
+const ZoomBoxStyle = styled.div`
+  background-color: ${color.white};
+  width: 80%;
+  height: 60px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: 20px;
+  padding-right: 20px;
+`;
+
+const InputStyle = styled.input.attrs({ type: 'range' })`
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  background: ${color.gray300};
+  border-radius: 999px;
+  height: 8px;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    background: ${color.white};
+    border: 1px solid ${color.maruDefault};
+    border-radius: 50%;
+    position: relative;
+    cursor: pointer;
+    box-shadow: 0 0 0 2px ${color.maruLightBlue};
+  }
 `;

--- a/apps/user/src/components/form/CropImageModal/CropImageModal.tsx
+++ b/apps/user/src/components/form/CropImageModal/CropImageModal.tsx
@@ -5,7 +5,7 @@ import { flex } from '@maru/utils';
 import styled from 'styled-components';
 import type { Area } from 'react-easy-crop';
 import Cropper from 'react-easy-crop';
-import { getCroppedImg } from '@/utils';
+import { getCropImg } from '@/utils';
 
 interface Props {
   isOpen: boolean;
@@ -16,25 +16,25 @@ interface Props {
 
 const CropImageModal = ({ isOpen, imageSrc, onClose, onCropComplete }: Props) => {
   const [crop, setCrop] = useState({ x: 0, y: 0 });
-  const [croppedArea, setCroppedArea] = useState<Area | null>(null);
+  const [cropArea, setCropArea] = useState<Area | null>(null);
 
   const onCropCompleteInternal = useCallback(
-    (croppedArea: Area, croppedAreaPixels: Area) => {
-      setCroppedArea(croppedAreaPixels);
+    (cropArea: Area, croppedAreaPixels: Area) => {
+      setCropArea(croppedAreaPixels);
     },
     []
   );
 
-  const applyCrop = useCallback(async () => {
-    if (!croppedArea) return;
-    const croppedImage = await getCroppedImg(imageSrc, croppedArea, 117, 156);
+  const handleApplyCrop = useCallback(async () => {
+    if (!cropArea) return;
+    const croppedImage = await getCropImg(imageSrc, cropArea, 117, 156);
 
     const response = await fetch(croppedImage as string);
     const blob = await response.blob();
 
     onCropComplete(blob);
     onClose();
-  }, [imageSrc, croppedArea, onCropComplete, onClose]);
+  }, [imageSrc, cropArea, onCropComplete, onClose]);
 
   if (!isOpen) return null;
 
@@ -54,7 +54,7 @@ const CropImageModal = ({ isOpen, imageSrc, onClose, onCropComplete }: Props) =>
               }}
             />
           </CropImageModalStyle>
-          <Button onClick={applyCrop}>
+          <Button onClick={handleApplyCrop}>
             <Text fontType="btn1" color={color.white}>
               사진 자르기 적용
             </Text>

--- a/apps/user/src/components/form/ProfileUploader/ProfileUploader.tsx
+++ b/apps/user/src/components/form/ProfileUploader/ProfileUploader.tsx
@@ -7,6 +7,7 @@ import { flex } from '@maru/utils';
 import type { ChangeEventHandler, DragEvent } from 'react';
 import { useState, useEffect } from 'react';
 import styled, { css } from 'styled-components';
+import CropImageModal from '../CropImageModal/CropImageModal';
 
 const ProfileUploader = ({
   onPhotoUpload,
@@ -20,11 +21,13 @@ const ProfileUploader = ({
   const [isDragging, setIsDragging] = useState(false);
   const { openFileUploader: openImageFileUploader, ref: imageUploaderRef } =
     useOpenFileUploader();
-  const { uploadProfileImageMutate } = useUploadProfileImageMutation();
-
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [imagePreviewUrl, setImagePreviewUrl] = useState(
     form.applicant.identificationPictureUri
   );
+
+  const { uploadProfileImageMutate } = useUploadProfileImageMutation();
 
   const uploadProfileImageFile = (image: FormData) => {
     uploadProfileImageMutate(image, {
@@ -46,9 +49,25 @@ const ProfileUploader = ({
   const handleImageFileChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { files } = e.target;
     if (!files || files.length === 0) return;
-    const formData = new FormData();
-    formData.append('image', files[0]);
-    uploadProfileImageFile(formData);
+
+    const file = files[0];
+    const img = new Image();
+    img.src = URL.createObjectURL(file);
+    img.onload = () => {
+      if (img.width < 117 || img.height < 156) {
+        alert('사진 크기가 너무 작습니다.');
+        return;
+      }
+
+      if (img.width > 117 || img.height > 156) {
+        setImageSrc(URL.createObjectURL(file));
+        setIsModalOpen(true);
+      } else {
+        const formData = new FormData();
+        formData.append('image', file, 'image.jpg');
+        uploadProfileImageFile(formData);
+      }
+    };
   };
 
   const onDragEnter = (e: DragEvent<HTMLDivElement>) => {
@@ -71,9 +90,24 @@ const ProfileUploader = ({
   const onDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    const formData = new FormData();
-    formData.append('image', e.dataTransfer.files[0]);
-    uploadProfileImageFile(formData);
+    const file = e.dataTransfer.files[0];
+    const img = new Image();
+    img.src = URL.createObjectURL(file);
+    img.onload = () => {
+      if (img.width < 117 || img.height < 156) {
+        alert('사진 크기가 너무 작습니다.');
+        return;
+      }
+
+      if (img.width > 117 || img.height > 156) {
+        setImageSrc(URL.createObjectURL(file));
+        setIsModalOpen(true);
+      } else {
+        const formData = new FormData();
+        formData.append('image', file, 'image.jpg');
+        uploadProfileImageFile(formData);
+      }
+    };
     setIsDragging(false);
   };
 
@@ -127,6 +161,18 @@ const ProfileUploader = ({
         onChange={handleImageFileChange}
         hidden
       />
+      {imageSrc && (
+        <CropImageModal
+          isOpen={isModalOpen}
+          imageSrc={imageSrc}
+          onClose={() => setIsModalOpen(false)}
+          onCropComplete={(croppedImage) => {
+            const formData = new FormData();
+            formData.append('image', croppedImage, 'image.jpg');
+            uploadProfileImageFile(formData);
+          }}
+        />
+      )}
     </StyledProfileUploader>
   );
 };

--- a/apps/user/src/components/form/ProfileUploader/ProfileUploader.tsx
+++ b/apps/user/src/components/form/ProfileUploader/ProfileUploader.tsx
@@ -168,9 +168,10 @@ const ProfileUploader = ({
           onClose={() => setIsModalOpen(false)}
           onCropComplete={(croppedImage) => {
             const formData = new FormData();
-            formData.append('image', croppedImage, 'image.jpg');
+            formData.append('image', croppedImage, 'image.png, image.jpg, image.jpeg');
             uploadProfileImageFile(formData);
           }}
+          zoom={1}
         />
       )}
     </StyledProfileUploader>

--- a/apps/user/src/components/form/index.ts
+++ b/apps/user/src/components/form/index.ts
@@ -11,3 +11,4 @@ export { default as GradePreview } from './GradePreview/GradePreview';
 export { default as PdfGeneratedLoader } from './PdfGeneratedLoader/PdfGeneratedLoader';
 export { default as ProfileUploader } from './ProfileUploader/ProfileUploader';
 export { default as ProgressSteps } from './ProgressSteps/ProgressSteps';
+export { default as CropImageModal } from './CropImageModal/CropImageModal';

--- a/apps/user/src/utils/cropImage.ts
+++ b/apps/user/src/utils/cropImage.ts
@@ -14,7 +14,7 @@ interface PixelCrop {
   height: number;
 }
 
-export const getCroppedImg = async (
+export const getCropImg = async (
   imageSrc: string,
   pixelCrop: PixelCrop,
   outputWidth = 117,

--- a/apps/user/src/utils/cropImage.ts
+++ b/apps/user/src/utils/cropImage.ts
@@ -1,0 +1,68 @@
+const createImage = (url: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener('load', () => resolve(image));
+    image.addEventListener('error', (error) => reject(error));
+    image.setAttribute('crossOrigin', 'anonymous');
+    image.src = url;
+  });
+
+interface PixelCrop {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export const getCroppedImg = async (
+  imageSrc: string,
+  pixelCrop: PixelCrop,
+  outputWidth = 117,
+  outputHeight = 156
+) => {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+
+  canvas.width = outputWidth * 2;
+  canvas.height = outputHeight * 2;
+
+  if (!ctx) {
+    throw new Error('Canvas 2D context not available');
+  }
+
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
+
+  ctx.drawImage(
+    image,
+    pixelCrop.x,
+    pixelCrop.y,
+    pixelCrop.width,
+    pixelCrop.height,
+    0,
+    0,
+    outputWidth * 2,
+    outputHeight * 2
+  );
+
+  const downscaledCanvas = document.createElement('canvas');
+  const downscaledCtx = downscaledCanvas.getContext('2d');
+
+  downscaledCanvas.width = outputWidth;
+  downscaledCanvas.height = outputHeight;
+
+  if (!downscaledCtx) {
+    throw new Error('Canvas 2D context not available');
+  }
+
+  downscaledCtx.drawImage(canvas, 0, 0, outputWidth, outputHeight);
+
+  return new Promise((resolve) => {
+    downscaledCanvas.toBlob((blob) => {
+      if (blob) {
+        resolve(URL.createObjectURL(blob));
+      }
+    }, 'image/jpeg');
+  });
+};

--- a/apps/user/src/utils/index.ts
+++ b/apps/user/src/utils/index.ts
@@ -5,4 +5,4 @@ export { default as updateSlicedSubjectList } from './updateSlicedSubjectList';
 export { default as formatApplicationDate } from './formatApplicationDate';
 export { default as formatStartDate } from './formatStartDate';
 export { formatStatus } from './formatStatus';
-export { getCroppedImg } from './cropImage';
+export { getCropImg } from './cropImage';

--- a/apps/user/src/utils/index.ts
+++ b/apps/user/src/utils/index.ts
@@ -5,3 +5,4 @@ export { default as updateSlicedSubjectList } from './updateSlicedSubjectList';
 export { default as formatApplicationDate } from './formatApplicationDate';
 export { default as formatStartDate } from './formatStartDate';
 export { formatStatus } from './formatStatus';
+export { getCroppedImg } from './cropImage';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,7 +207,7 @@ importers:
         version: 1.11.8
       next:
         specifier: 13.5.2
-        version: 13.5.2(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.5.2(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -217,6 +217,9 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      react-easy-crop:
+        specifier: ^5.0.7
+        version: 5.0.7(react-dom@18.2.0)(react@18.2.0)
       recoil:
         specifier: ^0.7.7
         version: 0.7.7(react-dom@18.2.0)(react@18.2.0)
@@ -787,6 +790,21 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.22.5):
+    resolution: {integrity: sha512-k0qnnOqHn5dK9pZpfD5XXZ9SojAITdCKRn2Lp6rnDGzIbaP0rHyMPk/4wsSxVBVz4RfN0q6VpXWP2pDGIoQ7hw==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/helper-compilation-targets': 7.22.10
+      '@babel/helper-plugin-utils': 7.22.5
+      debug: 4.3.4
+      lodash.debounce: 4.0.8
+      resolve: 1.22.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helper-environment-visitor@7.22.5:
     resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
     engines: {node: '>=6.9.0'}
@@ -890,6 +908,18 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.22.10
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-wrap-function': 7.22.10
+    dev: true
+
+  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.22.5):
+    resolution: {integrity: sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-wrap-function': 7.22.10
@@ -1598,6 +1628,19 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.10)
     dev: true
 
+  /@babel/plugin-transform-async-generator-functions@7.22.10(@babel/core@7.22.5):
+    resolution: {integrity: sha512-eueE8lvKVzq5wIObKK/7dvoeKJ+xc6TvRn6aysIjS6pSCeLy7S/eVi7pEQknZqyqvzaNKdDtem8nUNTBgDVR2g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.22.5)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.5)
+    dev: true
+
   /@babel/plugin-transform-async-generator-functions@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-gGOEvFzm3fWoyD5uZq7vVTD57pPJ3PczPUD/xCFGjzBpUosnklmXyKnGQbbbGs1NPNPskFex0j93yKbHt0cHyg==}
     engines: {node: '>=6.9.0'}
@@ -1665,6 +1708,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.10
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-transform-block-scoping@7.22.10(@babel/core@7.22.5):
+    resolution: {integrity: sha512-1+kVpGAOOI1Albt6Vse7c8pHzcZQdQKW+wJH+g8mCaszOdDVwRXa/slHPqIw+oJAJANTKDMuM2cBdV0Dg618Vg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -1768,6 +1821,26 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/plugin-transform-classes@7.22.6(@babel/core@7.22.5):
+    resolution: {integrity: sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-compilation-targets': 7.22.10
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.22.10):
     resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==}
     engines: {node: '>=6.9.0'}
@@ -1796,6 +1869,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.10
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-transform-destructuring@7.22.10(@babel/core@7.22.5):
+    resolution: {integrity: sha512-dPJrL0VOyxqLM9sritNbMSGx/teueHF/htMKrPT7DNxccXxRDPYqlgPFFdr8u+F+qUZOkZoXue/6rL5O5GduEw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -2317,6 +2400,18 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.10)
     dev: true
 
+  /@babel/plugin-transform-optional-chaining@7.22.10(@babel/core@7.22.5):
+    resolution: {integrity: sha512-MMkQqZAZ+MGj+jGTG3OTuhKeBpNcO+0oCEbrGNEaOmiEn+1MzRyQlYsruGiU8RTK3zV6XwrVJTmwiDOyYK6J9g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.5)
+    dev: true
+
   /@babel/plugin-transform-optional-chaining@7.22.5(@babel/core@7.22.10):
     resolution: {integrity: sha512-AconbMKOMkyG+xCng2JogMCDcqW8wedQAqpVIL4cOSescZ7+iW8utC6YDZLMCSUIReEA733gzRSaOSXMAt/4WQ==}
     engines: {node: '>=6.9.0'}
@@ -2529,6 +2624,17 @@ packages:
       regenerator-transform: 0.15.2
     dev: true
 
+  /@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.22.5):
+    resolution: {integrity: sha512-F28b1mDt8KcT5bUyJc/U9nwzw6cV+UmTeRlXYIl2TNqMMJif0Jeey9/RQ3C4NOd2zp0/TRsDns9ttj2L523rsw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      regenerator-transform: 0.15.2
+    dev: true
+
   /@babel/plugin-transform-regenerator@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-rR7KePOE7gfEtNTh9Qw+iO3Q/e4DEsoQ+hdvM6QUDH7JRJ5qxq5AA52ZzBWbI5i9lfNuvySgOGP8ZN7LAmaiPw==}
     engines: {node: '>=6.9.0'}
@@ -2711,6 +2817,16 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
+  /@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.22.5):
+    resolution: {integrity: sha512-lRfaRKGZCBqDlRU3UIFovdp9c9mEvlylmpod0/OatICsSfuQ9YFthRo1tpTkGsklEefZdqlEFdY4A2dwTb6ohg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
   /@babel/plugin-transform-unicode-escapes@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-biEmVg1IYB/raUO5wT1tgfacCef15Fbzhkx493D3urBI++6hpJ+RFG4SrWMn0NEZLfvilqKf3QDrRVZHo08FYg==}
     engines: {node: '>=6.9.0'}
@@ -2874,6 +2990,97 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/preset-env@7.22.10(@babel/core@7.22.5):
+    resolution: {integrity: sha512-riHpLb1drNkpLlocmSyEg4oYJIQFeXAK/d7rI6mbD0XsvoTOOweXDmQPG/ErxsEhWk3rl3Q/3F6RFQlVFS8m0A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.22.20
+      '@babel/core': 7.22.5
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.15
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.5)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.5)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.22.5)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.5)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.5)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.5)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.22.5)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.5)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.5)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.5)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.5)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.5)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.5)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.5)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.22.5)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-async-generator-functions': 7.22.10(@babel/core@7.22.5)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-block-scoping': 7.22.10(@babel/core@7.22.5)
+      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.22.5)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-destructuring': 7.22.10(@babel/core@7.22.5)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.22.5)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.22.5)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.22.5)
+      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.22.5)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.22.5)
+      '@babel/types': 7.22.10
+      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.22.5)
+      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.22.5)
+      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.22.5)
+      core-js-compat: 3.31.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/preset-env@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-fj06hw89dpiZzGZtxn+QybifF07nNiZjZ7sazs2aVDcysAZVGjW7+7iFYxg6GLNM47R/thYfLdrXc+2f11Vi9A==}
     engines: {node: '>=6.9.0'}
@@ -2994,6 +3201,17 @@ packages:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/core': 7.22.10
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/types': 7.22.10
+      esutils: 2.0.3
+    dev: true
+
+  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.22.5):
+    resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
+    dependencies:
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/types': 7.22.10
       esutils: 2.0.3
@@ -5434,7 +5652,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/core': 7.22.10
-      '@babel/preset-env': 7.22.10(@babel/core@7.22.10)
+      '@babel/preset-env': 7.22.10(@babel/core@7.22.5)
       '@babel/types': 7.22.10
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 7.3.1
@@ -5794,7 +6012,7 @@ packages:
       fs-extra: 11.1.1
       image-size: 1.0.2
       loader-utils: 3.2.1
-      next: 13.5.2(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.5.2(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.88.2)
       pnp-webpack-plugin: 1.7.0(typescript@5.1.3)
       postcss: 8.4.24
@@ -7689,6 +7907,19 @@ packages:
       - supports-color
     dev: true
 
+  /babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.22.5):
+    resolution: {integrity: sha512-19hwUH5FKl49JEsvyTcoHakh6BE0wgXLLptIyKZ3PijHc/Ci521wygORCUCCred+E/twuqRyAkE02BAWPmsHOg==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+    dependencies:
+      '@babel/compat-data': 7.22.9
+      '@babel/core': 7.22.5
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.5)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /babel-plugin-polyfill-corejs3@0.8.1(@babel/core@7.22.5):
     resolution: {integrity: sha512-ikFrZITKg1xH6pLND8zT14UPgjKHiGLqex7rGEZCH2EvhsneJaJPemmpQaIZV5AL03II+lXylw3UmddDK8RU5Q==}
     peerDependencies:
@@ -7712,6 +7943,18 @@ packages:
       - supports-color
     dev: true
 
+  /babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.22.5):
+    resolution: {integrity: sha512-z41XaniZL26WLrvjy7soabMXrfPWARN25PZoriDEiLMxAp50AUW3t35BGQUMg5xK3UrpVTtagIDklxYa+MhiNA==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.5)
+      core-js-compat: 3.31.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /babel-plugin-polyfill-regenerator@0.5.0(@babel/core@7.22.5):
     resolution: {integrity: sha512-hDJtKjMLVa7Z+LwnTCxoDLQj6wdc+B8dun7ayF2fYieI6OzfuvcLMB32ihJZ4UhCBwNYGl5bg/x/P9cMdnkc2g==}
     peerDependencies:
@@ -7729,6 +7972,17 @@ packages:
     dependencies:
       '@babel/core': 7.22.10
       '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.10)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.22.5):
+    resolution: {integrity: sha512-tAlOptU0Xj34V1Y2PNTL4Y0FOJMDB6bZmoW39FeCQIhigGLkqu3Fj6uiXpxIf6Ij274ENdYx64y6Au+ZKlb1IA==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12335,7 +12589,7 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /next@13.5.2(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0):
+  /next@13.5.2(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-vog4UhUaMYAzeqfiAAmgB/QWLW7p01/sg+2vn6bqc/CxHFYizMzLv6gjxKzl31EVFkfl/F+GbxlKizlkTE9RdA==}
     engines: {node: '>=16.14.0'}
     hasBin: true
@@ -12357,7 +12611,7 @@ packages:
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.22.10)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.22.5)(react@18.2.0)
       watchpack: 2.4.0
       zod: 3.21.4
     optionalDependencies:
@@ -12551,6 +12805,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
     requiresBuild: true
+
+  /normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+    dev: false
 
   /npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -13489,6 +13747,18 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+
+  /react-easy-crop@5.0.7(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-6d5IUt09M3HwdDGwrcjPVgfrOfYWAOku8sCTn/xU7b1vkEg+lExMLwW8UbR39L8ybQi0hJZTU57yprF9h5Q5Ig==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.6.2
+    dev: false
 
   /react-element-to-jsx-string@15.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==}
@@ -14631,6 +14901,23 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.22.10
+      client-only: 0.0.1
+      react: 18.2.0
+
+  /styled-jsx@5.1.1(@babel/core@7.22.5)(react@18.2.0):
+    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.5
       client-only: 0.0.1
       react: 18.2.0
 


### PR DESCRIPTION
## 📄 Summary

> 사진 규격이 117*156이어야만 사진이 등록이 된다. 하지만 이보다 크면 규격에 맞게 사진을 잘라서 등록하도록 해야하는 것이 좋다고 하여 이를 위해 개발을 했습니다.

<br>

## 🔨 Tasks

- 117*156으로만 사진이 자르도록 util 추가
- 사진을 선택하고 크면 자르는 모달이 뜨고 같다면 바로 등록이 되도록 로직 수정

<br>

## 🙋🏻 More
처음에는 사진을 넣으면 자동으로 사진의 크기를 117*156으로 작아지도록 기능을 canvas를 사용하여 개발했었는데 사진이 많이 안 좋아져서 라이브러리를 사용하기로 했었는데 react-easy-crop이 우리가 원하던 라이브러리와 가장 흡사하여 이를 사용했는데 자를때는 화질이 그대로였다가 자르고 나면 사진 화질이 급격하게 낮아져 이를 고쳐 조금은 화질이 개선되도록 하였습니다. 하지만 다른 라이브러리나 해당 라이브러리를 유지하고 화질이 낮아지지 않도록 하는 방법은 없는지 궁금합니다.


https://github.com/user-attachments/assets/36b3e14f-fbd9-48a7-beff-7223da5e7b7d


