### PR TITLE
fix(user): 고입검정이면 전형선택시 일반 전형 제외 나머지의 Radio 버튼은 disabled로 수정

### DIFF
--- a/apps/user/src/app/form/전형선택/전형선택.tsx
+++ b/apps/user/src/app/form/전형선택/전형선택.tsx
@@ -12,6 +12,9 @@ const 전형선택 = () => {
   const { handleFormTypeChange } = useInput();
   const { handleMoveNextStep, handleMovePreviousStep } = useCTAButton();
 
+  const isQualificationExamination =
+    form.education.graduationType === 'QUALIFICATION_EXAMINATION';
+
   useEffect(() => {
     if (form.education.graduationType === 'QUALIFICATION_EXAMINATION') {
       // 검정고시를 선택하였는데 특별전형으로 지원하였을때 필터링
@@ -78,6 +81,7 @@ const 전형선택 = () => {
                   value="MEISTER_TALENT"
                   onChange={handleFormTypeChange}
                   checked={form.type === 'MEISTER_TALENT'}
+                  disabled={isQualificationExamination}
                 />
               </Td>
             </Row>
@@ -96,6 +100,7 @@ const 전형선택 = () => {
                       value="NATIONAL_BASIC_LIVING"
                       onChange={handleFormTypeChange}
                       checked={form.type === 'NATIONAL_BASIC_LIVING'}
+                      disabled={isQualificationExamination}
                     />
                   </Td>
                 </Row>
@@ -109,6 +114,7 @@ const 전형선택 = () => {
                       value="NEAR_POVERTY"
                       onChange={handleFormTypeChange}
                       checked={form.type === 'NEAR_POVERTY'}
+                      disabled={isQualificationExamination}
                     />
                   </Td>
                 </Row>
@@ -122,6 +128,7 @@ const 전형선택 = () => {
                       value="NATIONAL_VETERANS"
                       onChange={handleFormTypeChange}
                       checked={form.type === 'NATIONAL_VETERANS'}
+                      disabled={isQualificationExamination}
                     />
                   </Td>
                 </Row>
@@ -135,6 +142,7 @@ const 전형선택 = () => {
                       value="ONE_PARENT"
                       onChange={handleFormTypeChange}
                       checked={form.type === 'ONE_PARENT'}
+                      disabled={isQualificationExamination}
                     />
                   </Td>
                 </Row>
@@ -155,6 +163,7 @@ const 전형선택 = () => {
                       value="FROM_NORTH_KOREA"
                       onChange={handleFormTypeChange}
                       checked={form.type === 'FROM_NORTH_KOREA'}
+                      disabled={isQualificationExamination}
                     />
                   </Td>
                 </Row>
@@ -168,6 +177,7 @@ const 전형선택 = () => {
                       value="MULTICULTURAL"
                       onChange={handleFormTypeChange}
                       checked={form.type === 'MULTICULTURAL'}
+                      disabled={isQualificationExamination}
                     />
                   </Td>
                 </Row>
@@ -181,6 +191,7 @@ const 전형선택 = () => {
                       value="TEEN_HOUSEHOLDER"
                       onChange={handleFormTypeChange}
                       checked={form.type === 'TEEN_HOUSEHOLDER'}
+                      disabled={isQualificationExamination}
                     />
                   </Td>
                 </Row>
@@ -194,6 +205,7 @@ const 전형선택 = () => {
                       value="MULTI_CHILDREN"
                       onChange={handleFormTypeChange}
                       checked={form.type === 'MULTI_CHILDREN'}
+                      disabled={isQualificationExamination}
                     />
                   </Td>
                 </Row>
@@ -207,6 +219,7 @@ const 전형선택 = () => {
                       value="FARMING_AND_FISHING"
                       onChange={handleFormTypeChange}
                       checked={form.type === 'FARMING_AND_FISHING'}
+                      disabled={isQualificationExamination}
                     />
                   </Td>
                 </Row>
@@ -241,6 +254,7 @@ const 전형선택 = () => {
                 value="NATIONAL_VETERANS_EDUCATION"
                 onChange={handleFormTypeChange}
                 checked={form.type === 'NATIONAL_VETERANS_EDUCATION'}
+                disabled={isQualificationExamination}
               />
             </Td>
             <Td width={80} height={56} borderBottomRightRadius={12}>
@@ -249,6 +263,7 @@ const 전형선택 = () => {
                 value="SPECIAL_ADMISSION"
                 onChange={handleFormTypeChange}
                 checked={form.type === 'SPECIAL_ADMISSION'}
+                disabled={isQualificationExamination}
               />
             </Td>
           </Column>

--- a/packages/ui/src/Radio/Radio.tsx
+++ b/packages/ui/src/Radio/Radio.tsx
@@ -1,10 +1,11 @@
 import { flex } from '@maru/utils';
 import type { InputHTMLAttributes } from 'react';
+import React from 'react';
 import { styled } from 'styled-components';
 
 type Props = InputHTMLAttributes<HTMLInputElement>;
 
-const Radio = ({ value, name, checked, onChange }: Props) => {
+const Radio = ({ value, name, checked, onChange, disabled }: Props) => {
   return (
     <StyledRadio>
       <RadioInput
@@ -13,6 +14,7 @@ const Radio = ({ value, name, checked, onChange }: Props) => {
         name={name}
         checked={checked}
         onChange={onChange}
+        disabled={disabled}
       />
     </StyledRadio>
   );


### PR DESCRIPTION
## 📄 Summary

> 고입검정으로 지원가능한 전형은 일반전형뿐입니다. 그래서 고입검정이 아닐때 전형을 다른걸로 지원하고 다시 고입검정으로 바꾸면 자동으로 일반전형으로 지원되도록 되어있고 고입검정에서 다른 전형선택하면 alert가 띄우면서 일반전형으로 선택됨. 하지만 이가 사용자에게 불편함을 줄수 있어 고입검정때는 일반전형만 선택가능하고 나머지는 disabled로 수정됩니다.

<br>

## 🔨 Tasks

- Radio버튼에 disabled 추가
- 고입검정일때만 disabled되도록 조건 추가

<br>

## 🙋🏻 More
