### PR TITLE
fix(user): 초안 작성 완료에서 이동하면 correct를 쿠키에 저장하고 수정하고 넘어가기를 누르면 바로 초안 작성 완료 페이지로 이동되도록 수정

### DIFF
--- a/apps/user/src/apis/storage/storage.ts
+++ b/apps/user/src/apis/storage/storage.ts
@@ -5,7 +5,8 @@ type CookieKey =
   | 'refresh-token'
   | 'noticeModalClosed'
   | 'isUploadPicture'
-  | 'downloadUrl';
+  | 'downloadUrl'
+  | 'correct';
 const cookies = new Cookies();
 
 export class Storage {

--- a/apps/user/src/app/form/보호자정보/보호자정보.hooks.ts
+++ b/apps/user/src/app/form/보호자정보/보호자정보.hooks.ts
@@ -1,15 +1,25 @@
+import { Storage } from '@/apis/storage/storage';
 import { useSaveFormMutation } from '@/services/form/mutations';
 import { useFormValueStore, useSetFormStepStore, useSetFormStore } from '@/store';
 import type { ChangeEventHandler } from 'react';
+import { useCookies } from 'react-cookie';
 
 export const useCTAButton = () => {
   const form = useFormValueStore();
   const { saveFormMutate } = useSaveFormMutation();
   const setFormStep = useSetFormStepStore();
+  const correct = Storage.getItem('correct');
+  const [, , removeCookie] = useCookies(['correct']);
 
   const handleMoveNextStep = () => {
-    setFormStep('출신학교및학력');
-    saveFormMutate(form);
+    if (correct) {
+      setFormStep('초안작성완료');
+      saveFormMutate(form);
+      removeCookie('correct');
+    } else {
+      setFormStep('출신학교및학력');
+      saveFormMutate(form);
+    }
   };
 
   const handleMovePreviousStep = () => {

--- a/apps/user/src/app/form/보호자정보/보호자정보.tsx
+++ b/apps/user/src/app/form/보호자정보/보호자정보.tsx
@@ -5,6 +5,7 @@ import { ButtonInput, Column, Input, Row } from '@maru/ui';
 import { useOverlay } from '@toss/use-overlay';
 import { useCTAButton, useInput } from './보호자정보.hooks';
 import { useState } from 'react';
+import { Storage } from '@/apis/storage/storage';
 
 const 보호자정보 = () => {
   const overlay = useOverlay();
@@ -18,6 +19,8 @@ const 보호자정보 = () => {
   const [isParentRelationError, setIsParentRelationError] = useState(false);
   const [isAddressError, setIsAddressError] = useState(false);
   const [isDetailAddressError, setIsDetailAddressError] = useState(false);
+
+  const correct = Storage.getItem('correct');
 
   const validateForm = () => {
     const nameValid = form.parent.name.length >= 2 && form.parent.name.length <= 5;
@@ -60,7 +63,7 @@ const 보호자정보 = () => {
     if (isNextClicked) {
       const { name, value } = e.target;
       if (name === 'name') {
-        setIsParentNameError(value.length === null);
+        setIsParentNameError(value.length < 2 || value.length > 5);
       } else if (name === 'phoneNumber') {
         setIsParentPhoneNumberError(value.length !== 11);
       } else if (name === 'relation') {
@@ -73,7 +76,7 @@ const 보호자정보 = () => {
     }
   };
 
-  const openFindAdressModal = () => {
+  const openFindAddressModal = () => {
     overlay.open(({ isOpen, close }) => (
       <FindAddressModal isOpen={isOpen} onClose={close} />
     ));
@@ -117,7 +120,7 @@ const 보호자정보 = () => {
         <ButtonInput
           label="주소"
           buttonText="검색"
-          onClick={openFindAdressModal}
+          onClick={openFindAddressModal}
           width="100%"
           value={form.parent.address}
           placeholder="예) 부산광역시 강서구 가락대로 1393 봉림동 15 "
@@ -147,7 +150,7 @@ const 보호자정보 = () => {
         </Row>
       </Column>
       <FormController
-        onPrevious={handleMovePreviousStep}
+        onPrevious={correct ? undefined : handleMovePreviousStep}
         onNext={handleNextClick}
         step="보호자정보"
       />

--- a/apps/user/src/app/form/성적입력/자격증.hooks.ts
+++ b/apps/user/src/app/form/성적입력/자격증.hooks.ts
@@ -1,11 +1,15 @@
+import { Storage } from '@/apis/storage/storage';
 import { useSaveFormMutation } from '@/services/form/mutations';
 import { useFormValueStore, useSetFormStepStore, useSet성적입력StepStore } from '@/store';
+import { useCookies } from 'react-cookie';
 
 export const useCTAButton = () => {
   const form = useFormValueStore();
   const setFormStep = useSetFormStepStore();
   const set성적입력Step = useSet성적입력StepStore();
   const { saveFormMutate } = useSaveFormMutation();
+  const correct = Storage.getItem('correct');
+  const [, , removeCookie] = useCookies(['correct']);
 
   const handleMoveNextStep = () => {
     const isEmptySubjectName = form.grade.subjectList.some(({ subjectName }) => {
@@ -18,8 +22,14 @@ export const useCTAButton = () => {
     });
 
     if (!isEmptySubjectName) {
-      setFormStep('자기소개서');
-      saveFormMutate(form);
+      if (correct) {
+        setFormStep('초안작성완료');
+        saveFormMutate(form);
+        removeCookie('correct');
+      } else {
+        setFormStep('자기소개서');
+        saveFormMutate(form);
+      }
     }
   };
 

--- a/apps/user/src/app/form/전형선택/전형선택.hooks.ts
+++ b/apps/user/src/app/form/전형선택/전형선택.hooks.ts
@@ -1,6 +1,8 @@
+import { Storage } from '@/apis/storage/storage';
 import { useSaveFormMutation } from '@/services/form/mutations';
 import { useFormValueStore, useSetFormStepStore, useSetFormStore } from '@/store';
 import type { ChangeEventHandler } from 'react';
+import { useCookies } from 'react-cookie';
 
 export const useInput = () => {
   const setForm = useSetFormStore();
@@ -17,10 +19,18 @@ export const useCTAButton = () => {
   const form = useFormValueStore();
   const setFormStep = useSetFormStepStore();
   const { saveFormMutate } = useSaveFormMutation();
+  const correct = Storage.getItem('correct');
+  const [, , removeCookie] = useCookies(['correct']);
 
   const handleMoveNextStep = () => {
-    setFormStep('성적입력');
-    saveFormMutate(form);
+    if (correct) {
+      setFormStep('초안작성완료');
+      saveFormMutate(form);
+      removeCookie('correct');
+    } else {
+      setFormStep('성적입력');
+      saveFormMutate(form);
+    }
   };
 
   const handleMovePreviousStep = () => {

--- a/apps/user/src/app/form/지원자정보/지원자정보.hooks.ts
+++ b/apps/user/src/app/form/지원자정보/지원자정보.hooks.ts
@@ -4,15 +4,25 @@ import { useFormValueStore, useSetFormStepStore, useSetFormStore } from '@/store
 import useUser from '@/hooks/useUser';
 import { formatDate } from '@/utils';
 import { useSaveFormMutation } from '@/services/form/mutations';
+import { Storage } from '@/apis/storage/storage';
+import { useCookies } from 'react-cookie';
 
 export const useCTAButton = () => {
   const form = useFormValueStore();
   const setFormStep = useSetFormStepStore();
   const { saveFormMutate } = useSaveFormMutation();
+  const correct = Storage.getItem('correct');
+  const [, , removeCookie] = useCookies(['correct']);
 
   const handleMoveNextStep = () => {
-    setFormStep('보호자정보');
-    saveFormMutate(form);
+    if (correct) {
+      setFormStep('초안작성완료');
+      saveFormMutate(form);
+      removeCookie('correct');
+    } else {
+      setFormStep('보호자정보');
+      saveFormMutate(form);
+    }
   };
 
   return { handleMoveNextStep };

--- a/apps/user/src/app/form/출신학교및학력/출신학교및학력.hooks.ts
+++ b/apps/user/src/app/form/출신학교및학력/출신학교및학력.hooks.ts
@@ -1,15 +1,25 @@
+import { Storage } from '@/apis/storage/storage';
 import { useSaveFormMutation } from '@/services/form/mutations';
 import { useFormValueStore, useSetFormStepStore, useSetFormStore } from '@/store';
 import type { ChangeEventHandler } from 'react';
+import { useCookies } from 'react-cookie';
 
 export const useCTAButton = () => {
   const form = useFormValueStore();
   const setFormStep = useSetFormStepStore();
   const { saveFormMutate } = useSaveFormMutation();
+  const correct = Storage.getItem('correct');
+  const [, , removeCookie] = useCookies(['correct']);
 
   const handleMoveNextStep = () => {
-    setFormStep('전형선택');
-    saveFormMutate(form);
+    if (correct) {
+      setFormStep('초안작성완료');
+      saveFormMutate(form);
+      removeCookie('correct');
+    } else {
+      setFormStep('전형선택');
+      saveFormMutate(form);
+    }
   };
 
   const handleMovePreviousStep = () => {

--- a/apps/user/src/components/form/CheckFormCompleteBox/CheckFormCompleteBox.tsx
+++ b/apps/user/src/components/form/CheckFormCompleteBox/CheckFormCompleteBox.tsx
@@ -1,6 +1,7 @@
 import { useFormValueStore, useSetFormStepStore } from '@/store';
 import { styled } from 'styled-components';
 import CheckFormComplete from './CheckFormComplete/CheckFormComplete';
+import { Storage } from '@/apis/storage/storage';
 
 interface Props {
   applicantFilledCount: number;
@@ -20,22 +21,47 @@ const CheckFormCompleteBox = ({
   const setFormStep = useSetFormStepStore();
   const form = useFormValueStore();
 
+  const handleCorrect지원자정보 = () => {
+    setFormStep('지원자정보');
+    Storage.setItem('correct', '1');
+  };
+
+  const handleCorrect보호자정보 = () => {
+    setFormStep('보호자정보');
+    Storage.setItem('correct', '1');
+  };
+
+  const handleCorrect출신학교및학력 = () => {
+    setFormStep('출신학교및학력');
+    Storage.setItem('correct', '1');
+  };
+
+  const handleCorrect전형선택 = () => {
+    setFormStep('전형선택');
+    Storage.setItem('correct', '1');
+  };
+
+  const handleCorrect성적입력 = () => {
+    setFormStep('성적입력');
+    Storage.setItem('correct', '1');
+  };
+
   return (
     <StyledCheckFormCompleteBox>
       <CheckFormComplete
-        onClick={() => setFormStep('지원자정보')}
+        onClick={handleCorrect지원자정보}
         formStep="지원자 정보"
         maxCompleteOfNumber={5}
         completeOfNumber={applicantFilledCount}
       />
       <CheckFormComplete
-        onClick={() => setFormStep('보호자정보')}
+        onClick={handleCorrect보호자정보}
         formStep="보호자 정보"
         maxCompleteOfNumber={6}
         completeOfNumber={parentFilledCount}
       />
       <CheckFormComplete
-        onClick={() => setFormStep('출신학교및학력')}
+        onClick={handleCorrect출신학교및학력}
         formStep="출신학교 및 학력"
         maxCompleteOfNumber={
           form.education.graduationType === 'QUALIFICATION_EXAMINATION' ? +'2' : 9
@@ -43,13 +69,13 @@ const CheckFormCompleteBox = ({
         completeOfNumber={educationFilledCount}
       />
       <CheckFormComplete
-        onClick={() => setFormStep('전형선택')}
+        onClick={handleCorrect전형선택}
         formStep="전형 선택"
         maxCompleteOfNumber={1}
         completeOfNumber={typeFilledCount}
       />
       <CheckFormComplete
-        onClick={() => setFormStep('성적입력')}
+        onClick={handleCorrect성적입력}
         formStep="성적 입력"
         maxCompleteOfNumber={4}
         completeOfNumber={4}

--- a/apps/user/src/components/form/FormController/FormController.tsx
+++ b/apps/user/src/components/form/FormController/FormController.tsx
@@ -2,6 +2,7 @@ import type { FormStep } from '@/types/form/client';
 import { Button } from '@maru/ui';
 import { flex } from '@maru/utils';
 import styled from 'styled-components';
+import { Storage } from '@/apis/storage/storage';
 
 interface Props {
   onPrevious?: () => void;
@@ -10,9 +11,11 @@ interface Props {
 }
 
 const FormController = ({ onPrevious, onNext, step }: Props) => {
+  const correct = Storage.getItem('correct');
+
   return (
     <FormControllerBar>
-      {step === '지원자정보' ? (
+      {step === '지원자정보' || correct ? (
         <Button width={150} onClick={onNext}>
           다음 단계
         </Button>

--- a/apps/user/src/components/main/NoticeModal/NoticeModal.tsx
+++ b/apps/user/src/components/main/NoticeModal/NoticeModal.tsx
@@ -18,6 +18,13 @@ const NoticeModal = ({ isOpen, onClose }: Props) => {
   const isLoggedIn = Boolean(Storage.getItem('access-token'));
 
   useEffect(() => {
+    const noticeModalClosed = Storage.getItem('noticeModalClosed');
+
+    if (noticeModalClosed) {
+      onClose();
+      return;
+    }
+
     if (isOpen) {
       document.body.style.overflow = 'hidden';
     } else {
@@ -27,13 +34,17 @@ const NoticeModal = ({ isOpen, onClose }: Props) => {
     return () => {
       document.body.style.overflow = 'auto';
     };
-  }, [isOpen]);
+  }, [isOpen, onClose]);
 
-  const handleCloseModal = () => {
+  const handleCloseModal = (navigateToGuide = false) => {
     if (isLoggedIn) {
       Storage.setItem('noticeModalClosed', 'true');
     }
-    router.replace(ROUTES.MAIN);
+    if (navigateToGuide) {
+      router.push(UserGuide);
+    } else {
+      router.replace(ROUTES.MAIN);
+    }
     onClose();
   };
 
@@ -44,7 +55,7 @@ const NoticeModal = ({ isOpen, onClose }: Props) => {
       <StyledModal>
         <CloseButton>
           <IconClose
-            onClick={handleCloseModal}
+            onClick={() => handleCloseModal(false)}
             color={color.gray600}
             width={36}
             height={36}
@@ -65,7 +76,7 @@ const NoticeModal = ({ isOpen, onClose }: Props) => {
               </Text>
             </Column>
           </Column>
-          <Button type="button" onClick={() => router.push(UserGuide)}>
+          <Button type="button" onClick={() => handleCloseModal(true)}>
             <Text fontType="p1" color={color.white}>
               가이드 다운로드 페이지로 이동
             </Text>

--- a/apps/user/src/services/auth/mutations.ts
+++ b/apps/user/src/services/auth/mutations.ts
@@ -108,6 +108,7 @@ export const useLogoutUserMutation = () => {
     'noticeModalClosed',
     'isUploadPicture',
     'downloadUrl',
+    'correct',
   ]);
   const router = useRouter();
 
@@ -119,6 +120,7 @@ export const useLogoutUserMutation = () => {
       removeCookie('noticeModalClosed');
       removeCookie('isUploadPicture');
       removeCookie('downloadUrl');
+      removeCookie('correct');
       window.location.reload();
       router.replace(ROUTES.MAIN);
     },
@@ -128,6 +130,7 @@ export const useLogoutUserMutation = () => {
       removeCookie('noticeModalClosed');
       removeCookie('isUploadPicture');
       removeCookie('downloadUrl');
+      removeCookie('correct');
       window.location.reload();
     },
   });


### PR DESCRIPTION
## 📄 Summary

> 초안 작성 완료 페이지에서 각각의 페이지로 이동하면 쿠키에 correct가 저장이 된다. 여기서 수정하고 나서 넘어갈려고 하면 correct가 지워지면서 초안 작성 완료 페이지로 이동하게 되도록 수정하였습니다.

<br>

## 🔨 Tasks

- 쿠키에 correct 추가
- 이동할때마다 correct 추가하도록 수정
- correct가 있으면 이전 버튼이 안나오도록 수정
- correct가 있으면 다음 버튼 클릭시 초안 작성 완료 페이지로 이동

<br>

## 🙋🏻 More
