### PR TITLE
fix(user): 보호자 이름 조건 수정 및 유효성 검사 코드 수정

### DIFF
--- a/apps/user/src/app/form/보호자정보/보호자정보.tsx
+++ b/apps/user/src/app/form/보호자정보/보호자정보.tsx
@@ -23,7 +23,7 @@ const 보호자정보 = () => {
   const correct = Storage.getItem('correct');
 
   const validateForm = () => {
-    const nameValid = form.parent.name.length >= 2 && form.parent.name.length <= 5;
+    const nameValid = form.parent.name.length >= 2;
     const phoneNumberValid = form.parent.phoneNumber.length === 11;
     const relationValid = form.parent.relation.length > 0;
     const addressValid =
@@ -39,7 +39,7 @@ const 보호자정보 = () => {
   const handleNextClick = () => {
     setIsNextClicked(true);
 
-    const nameValid = form.parent.name.length === null;
+    const nameValid = form.parent.name.length >= 2;
     const phoneNumberValid = form.parent.phoneNumber.length === 11;
     const relationValid = form.parent.relation.length > 0;
     const addressValid =
@@ -60,10 +60,11 @@ const 보호자정보 = () => {
 
   const handle보호자정보ErrorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     handle보호자정보Change(e);
+    const { name, value } = e.target;
+
     if (isNextClicked) {
-      const { name, value } = e.target;
       if (name === 'name') {
-        setIsParentNameError(value.length < 2 || value.length > 5);
+        setIsParentNameError(value.length < 2);
       } else if (name === 'phoneNumber') {
         setIsParentPhoneNumberError(value.length !== 11);
       } else if (name === 'relation') {
@@ -123,7 +124,7 @@ const 보호자정보 = () => {
           onClick={openFindAddressModal}
           width="100%"
           value={form.parent.address}
-          placeholder="예) 부산광역시 강서구 가락대로 1393 봉림동 15 "
+          placeholder="예) 부산광역시 강서구 가락대로 1393 봉림동 15"
           isError={isAddressError}
           errorMessage={isAddressError ? '주소를 입력해주세요.' : ''}
         />

--- a/apps/user/src/app/form/초안작성완료/초안작성완료.hooks.ts
+++ b/apps/user/src/app/form/초안작성완료/초안작성완료.hooks.ts
@@ -22,7 +22,7 @@ const useFilledApplicantFieldsCount = (applicant: Form['applicant']) => {
 
       switch (key) {
         case 'name':
-          return acc + Number(value.length <= 20);
+          return acc + Number(value.length >= 2);
         case 'phoneNumber':
           return acc + Number(value.length === 11);
         default:
@@ -39,7 +39,7 @@ const useFilledParentFieldsCount = (parent: Form['parent']) =>
 
     switch (key) {
       case 'name':
-        return acc + Number(value.length <= 20);
+        return acc + Number(value.length >= 2);
       case 'phoneNumber':
         return acc + Number(value.length === 11);
       case 'address':
@@ -74,7 +74,7 @@ const useFilledEducationFieldsCount = (education: Form['education']) => {
       case 'schoolLocation':
       case 'schoolAddress':
       case 'teacherName':
-        return acc + Number(value.length <= 20);
+        return acc + Number(value.length >= 2);
       case 'graduationYear':
         return acc + Number(value.length === 4);
       case 'schoolCode':

--- a/apps/user/src/app/form/출신학교및학력/출신학교및학력.tsx
+++ b/apps/user/src/app/form/출신학교및학력/출신학교및학력.tsx
@@ -47,7 +47,7 @@ const 출신학교및학력 = () => {
       const schoolCodeValid = (schoolCode ?? '').length === 7;
       const teacherPhoneNumberValid = (teacherPhoneNumber ?? '').length >= 10;
       const teacherNameValid =
-        (teacherName ?? '').length > 0 && (teacherName ?? '').length < 20;
+        (teacherName ?? '').length > 0 && (teacherName ?? '').length >= 2;
       const teacherMobilePhoneNumberValid =
         (teacherMobilePhoneNumber ?? '').length === 11;
       const graduationYearValid = (graduationYear ?? '').length === 4;
@@ -123,8 +123,7 @@ const 출신학교및학력 = () => {
     );
     setIsTeacherNameError(
       form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
-        ((form.education.teacherName ?? '').length === 0 ||
-          (form.education.teacherName ?? '').length >= 20)
+        (form.education.teacherName ?? '').length < 2
     );
     setIsTeacherMobilePhoneNumberError(
       form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
@@ -150,8 +149,7 @@ const 출신학교및학력 = () => {
       );
       setIsTeacherNameError(
         form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&
-          ((form.education.teacherName ?? '').length === 0 ||
-            (form.education.teacherName ?? '').length >= 20)
+          (form.education.teacherName ?? '').length < 2
       );
       setIsTeacherMobilePhoneNumberError(
         form.education.graduationType !== 'QUALIFICATION_EXAMINATION' &&


### PR DESCRIPTION
## 📄 Summary

> 보호자 이름이 조건에 맞더라도 다른 필드의 값이 입력이되어 있지 않으면 이름또한 에러가 발생하는 원인이 발견되어 이를 수정하였습니다.

<br>

## 🔨 Tasks

- 이름은 이름의 필드의 값만 보고 조건에 다라 에러 메시지가 뜨도록 수정
- 이름을 2자 이상이도록 수정 (보호자, 작성교사, 초안작성완료)

<br>

## 🙋🏻 More
<img width="883" alt="스크린샷 2024-09-05 오전 12 31 18" src="https://github.com/user-attachments/assets/a5e913d7-1607-49d4-802a-ca51f50fe0ae">

