### PR TITLE
style(user): 제출 후 애니메이션 화면 클릭시 이벤트 안 일어나도록 수정

### DIFF
--- a/apps/user/src/app/form/초안제출완료/초안제출완료.tsx
+++ b/apps/user/src/app/form/초안제출완료/초안제출완료.tsx
@@ -60,6 +60,8 @@ const Styled초안제출완료 = styled.div`
   opacity: 0;
   animation: show 1.2s 2s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
 
+  pointer-events: none;
+
   @keyframes show {
     from {
       transform: translateY(200px);
@@ -67,6 +69,7 @@ const Styled초안제출완료 = styled.div`
     to {
       transform: translateY(0);
       opacity: 100;
+      pointer-events: auto;
     }
   }
 `;

--- a/apps/user/src/app/form/최종제출완료/최종제출완료.tsx
+++ b/apps/user/src/app/form/최종제출완료/최종제출완료.tsx
@@ -59,6 +59,8 @@ const Styled최종제출완료 = styled.div`
   opacity: 0;
   animation: show 1.2s 2s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
 
+  pointer-events: none;
+
   @keyframes show {
     from {
       transform: translateY(200px);
@@ -66,6 +68,7 @@ const Styled최종제출완료 = styled.div`
     to {
       transform: translateY(0);
       opacity: 100;
+      pointer-events: auto;
     }
   }
 `;


### PR DESCRIPTION
## 📄 Summary

> 원서 초안 제출, 원서 최종 제출 페이지에서 랜딩페이지로 애니메이션이 나오는데 이때 페이지를 클릭하여 하단에 컴포넌트가 있을시 클릭으로 이해 페이지 전환이 될 수 있는데 이를 해결하였습니다.

<br>

## 🔨 Tasks

- 원서 초안 제출 애니메이션 중 클릭안되도록 css 수정
- 원서 최종 제출 애니메이션 중 클릭안되도록 css 수정

<br>

## 🙋🏻 More
