### PR TITLE
fix(user): 1차, 최종 결과 페이지에서 상태에 따른 페이지 수정

### DIFF
--- a/apps/user/src/components/result/FinalResultTable/FinalResultTable.tsx
+++ b/apps/user/src/components/result/FinalResultTable/FinalResultTable.tsx
@@ -9,12 +9,9 @@ const FinalResultTable = () => {
   const { data: finalResultData } = useFinalResultQuery();
 
   return finalResultData ? (
-    <StyledFinalResultTable isPassed={finalResultData.passed}>
-      <Column gap={20} width={816}>
-        <FinalResultTableItem
-          type={finalResultData.type}
-          isPassed={finalResultData.passed}
-        />
+    <StyledFinalResultTable>
+      <Column gap={8} width={816}>
+        <FinalResultTableItem isPassed={finalResultData.passed} />
         <ResultTableFooter option="FINAL" isPassed={finalResultData.passed} />
       </Column>
     </StyledFinalResultTable>
@@ -23,7 +20,6 @@ const FinalResultTable = () => {
 
 export default FinalResultTable;
 
-const StyledFinalResultTable = styled.div<{ isPassed: boolean }>`
+const StyledFinalResultTable = styled.div`
   ${flex({ flexDirection: 'column', alignItems: 'center' })};
-  gap: ${(props) => (props.isPassed ? '1px' : '120px')};
 `;

--- a/apps/user/src/components/result/FinalResultTableItem/FinalResultTableItem.tsx
+++ b/apps/user/src/components/result/FinalResultTableItem/FinalResultTableItem.tsx
@@ -3,17 +3,13 @@ import { Column, Text } from '@maru/ui';
 import styled from 'styled-components';
 
 interface Props {
-  type: string;
   isPassed: boolean;
 }
 
-const FinalResultTableItem = ({ type, isPassed }: Props) => {
+const FinalResultTableItem = ({ isPassed }: Props) => {
   return (
     <StyledResultTableItem>
-      <Column alignItems="center" gap={10}>
-        <Text fontType="p1" color={color.gray600}>
-          {type}
-        </Text>
+      <Column alignItems="center">
         <Text fontType="H2" color={color.maruDefault}>
           {isPassed ? '합격을 축하합니다.' : '최종 합격자 명단에 없습니다.'}
         </Text>
@@ -28,7 +24,5 @@ const StyledResultTableItem = styled.div`
   align-items: center;
   justify-content: space-between;
   display: inline-block;
-  width: 100%;
-  height: 64px;
   background-color: ${color.white};
 `;

--- a/apps/user/src/components/result/FirstResultTable/FirstResultTable.tsx
+++ b/apps/user/src/components/result/FirstResultTable/FirstResultTable.tsx
@@ -14,6 +14,7 @@ const FirstResultTable = () => {
         <FirstResultTableItem
           type={firstResultData.type}
           isPassed={firstResultData.passed}
+          changedToRegular={firstResultData.changedToRegular}
         />
         <FirstResultTableFooter option="FIRST" isPassed={firstResultData.passed} />
       </Column>

--- a/apps/user/src/components/result/FirstResultTableItem/FirstResultTableItem.tsx
+++ b/apps/user/src/components/result/FirstResultTableItem/FirstResultTableItem.tsx
@@ -5,15 +5,20 @@ import styled from 'styled-components';
 interface Props {
   type: string;
   isPassed: boolean;
+  changedToRegular: boolean;
 }
 
-const FirstResultTableItem = ({ type, isPassed }: Props) => {
+const FirstResultTableItem = ({ type, isPassed, changedToRegular }: Props) => {
+  const displayType = changedToRegular ? '특별 전형 →  일반 전형' : type;
+
   return (
     <StyledResultTableItem>
       <Column alignItems="center" gap={10}>
-        <Text fontType="p1" color={color.gray600}>
-          {type}
-        </Text>
+        {isPassed && (
+          <Text fontType="p1" color={color.gray600}>
+            {displayType}
+          </Text>
+        )}
         <Text fontType="H2" color={color.maruDefault}>
           {isPassed ? '합격을 축하합니다.' : '1차 합격자 명단에 없습니다.'}
         </Text>

--- a/apps/user/src/types/result/client.ts
+++ b/apps/user/src/types/result/client.ts
@@ -7,4 +7,5 @@ export interface Result {
   name: string;
   type: string;
   passed: boolean;
+  changedToRegular: boolean;
 }


### PR DESCRIPTION
## 📄 Summary

> 결과페이지에서 어떤 전형으로 합격을 했는지 불합격을 헀는지를 보여주기 위해서 이를 수정하였습니다.

<br>

## 🔨 Tasks

- 1차에서 특별에서 일반에서 합격했을 경우 문구를 수정
- 최종에서는 합불 상관없이 전형을 보여주지 않도록 디자인이 되어 있어서 이를 수정
- 간격이 맞지 않는 부분이 생겨서 이를 수정

<br>

## 🙋🏻 More
