### PR TITLE
fix(user, admin): 공지사항 파일 다운로드시 uuid가 보이는 문제 해결

### DIFF
--- a/apps/admin/src/components/notice/NoticeDetailContent/NoticeDetailContent.tsx
+++ b/apps/admin/src/components/notice/NoticeDetailContent/NoticeDetailContent.tsx
@@ -18,10 +18,23 @@ const NoticeDetailContent = ({ id }: Props) => {
   const { data: noticeDetailData } = useNoticeDetailQuery(id);
   const { handleDeleteNoticeButtonClick } = useNoticeDeleteAction(id);
 
-  const handleFileDownload = () => {
-    if (noticeDetailData?.fileUrl) {
-      window.open(noticeDetailData.fileUrl, '_blank');
+  const handleFileDownload = async () => {
+    if (!noticeDetailData?.fileUrl) {
+      return;
     }
+
+    const response = await fetch(noticeDetailData.fileUrl);
+    const blob = await response.blob();
+
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = formatFileName(noticeDetailData.fileName || '');
+
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(url);
   };
 
   return noticeDetailData ? (

--- a/apps/user/src/components/notice/NoticeDetailContent/NoticeDetailContent.tsx
+++ b/apps/user/src/components/notice/NoticeDetailContent/NoticeDetailContent.tsx
@@ -13,10 +13,23 @@ interface Props {
 const NoticeDetailContent = ({ id }: Props) => {
   const { data: noticeDetailData } = useNoticeDetailQuery(id);
 
-  const handleFileDownload = () => {
-    if (noticeDetailData?.fileUrl) {
-      window.open(noticeDetailData.fileUrl, '_blank');
+  const handleFileDownload = async () => {
+    if (!noticeDetailData.fileUrl) {
+      return;
     }
+
+    const response = await fetch(noticeDetailData.fileUrl);
+    const blob = await response.blob();
+
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = formatFileName(noticeDetailData.fileName || '');
+
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(url);
   };
 
   return noticeDetailData ? (


### PR DESCRIPTION
## 📄 Summary

> 공지 사항 파일 다운로드시 uuid가 나오는 채로 다운로드 되는 문제가 생겨서 이를 수정했습니다.

<br>

## 🔨 Tasks

- uuid 있는 상태로 다운로드 안되도록 수정

<br>

## 🙋🏻 More
<img width="308" alt="스크린샷 2024-09-24 오후 11 54 59" src="https://github.com/user-attachments/assets/ef28fad3-6798-4f10-998b-c9f661b99f88">