### PR TITLE
fix(admin/user): 공지사항 파일 여러 개로 수정

### DIFF
--- a/apps/admin/src/components/notice/NoticeDetailContent/NoticeDetailContent.tsx
+++ b/apps/admin/src/components/notice/NoticeDetailContent/NoticeDetailContent.tsx
@@ -12,7 +12,6 @@ import { formatFileName } from '@/utils';
 interface Props {
   id: number;
 }
-
 const NoticeDetailContent = ({ id }: Props) => {
   const router = useRouter();
   const { data: noticeDetailData } = useNoticeDetailQuery(id);
@@ -68,30 +67,17 @@ const NoticeDetailContent = ({ id }: Props) => {
           <Content
             dangerouslySetInnerHTML={{ __html: convertLink(noticeDetailData.content) }}
           />
-          {/* console.log('여기 고쳐야함') */}
-          <Column>콘텐트: {noticeDetailData.content}</Column>
-          <Column>url: {noticeDetailData.fileUrls}</Column>
-          <Column>네임: {noticeDetailData.fileNames}</Column>
-          {noticeDetailData.fileUrls && noticeDetailData.fileNames && (
+          {noticeDetailData.fileList && (
             <Column gap={12}>
-              {noticeDetailData.fileUrls.map((fileUrl: string, index: number) => (
+              {noticeDetailData.fileList.map((file, index) => (
                 <StyledNoticeFile
                   key={index}
-                  onClick={() =>
-                    handleFileDownload(
-                      fileUrl,
-                      noticeDetailData.fileNames ? noticeDetailData.fileNames[index] : ''
-                    )
-                  }
+                  onClick={() => handleFileDownload(file.downloadUrl, file.fileName)}
                 >
                   <Row alignItems="center" gap={10}>
                     <IconClip width={19} height={12} />
                     <Text fontType="p3" color={color.gray750}>
-                      {formatFileName(
-                        noticeDetailData.fileNames
-                          ? noticeDetailData.fileNames[index]
-                          : ''
-                      )}
+                      {formatFileName(file.fileName)}
                     </Text>
                   </Row>
                 </StyledNoticeFile>

--- a/apps/admin/src/components/notice/NoticeDetailContent/NoticeDetailContent.tsx
+++ b/apps/admin/src/components/notice/NoticeDetailContent/NoticeDetailContent.tsx
@@ -18,18 +18,14 @@ const NoticeDetailContent = ({ id }: Props) => {
   const { data: noticeDetailData } = useNoticeDetailQuery(id);
   const { handleDeleteNoticeButtonClick } = useNoticeDeleteAction(id);
 
-  const handleFileDownload = async () => {
-    if (!noticeDetailData?.fileUrl) {
-      return;
-    }
-
-    const response = await fetch(noticeDetailData.fileUrl);
+  const handleFileDownload = async (fileUrl: string, fileName: string) => {
+    const response = await fetch(fileUrl);
     const blob = await response.blob();
 
     const url = window.URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = formatFileName(noticeDetailData.fileName || '');
+    link.download = fileName;
 
     document.body.appendChild(link);
     link.click();
@@ -72,15 +68,35 @@ const NoticeDetailContent = ({ id }: Props) => {
           <Content
             dangerouslySetInnerHTML={{ __html: convertLink(noticeDetailData.content) }}
           />
-          {noticeDetailData.fileUrl && (
-            <StyledNoticeFile onClick={handleFileDownload}>
-              <Row alignItems="center" gap={10}>
-                <IconClip width={19} height={12} />
-                <Text fontType="p3" color={color.gray750}>
-                  {formatFileName(noticeDetailData.fileName || '')}
-                </Text>
-              </Row>
-            </StyledNoticeFile>
+          {/* console.log('여기 고쳐야함') */}
+          <Column>콘텐트: {noticeDetailData.content}</Column>
+          <Column>url: {noticeDetailData.fileUrls}</Column>
+          <Column>네임: {noticeDetailData.fileNames}</Column>
+          {noticeDetailData.fileUrls && noticeDetailData.fileNames && (
+            <Column gap={12}>
+              {noticeDetailData.fileUrls.map((fileUrl: string, index: number) => (
+                <StyledNoticeFile
+                  key={index}
+                  onClick={() =>
+                    handleFileDownload(
+                      fileUrl,
+                      noticeDetailData.fileNames ? noticeDetailData.fileNames[index] : ''
+                    )
+                  }
+                >
+                  <Row alignItems="center" gap={10}>
+                    <IconClip width={19} height={12} />
+                    <Text fontType="p3" color={color.gray750}>
+                      {formatFileName(
+                        noticeDetailData.fileNames
+                          ? noticeDetailData.fileNames[index]
+                          : ''
+                      )}
+                    </Text>
+                  </Row>
+                </StyledNoticeFile>
+              ))}
+            </Column>
           )}
         </Column>
       </Column>

--- a/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.hooks.ts
+++ b/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.hooks.ts
@@ -17,6 +17,10 @@ export const useNotieEditAction = (id: number, noticeData: PutNoticeReq) => {
 
     if (fileData && fileData.length > 0) {
       const uploadedfileNameList = await uploadFile(fileData);
+      fileNameList = fileNameList.filter(
+        (fileName) =>
+          !uploadedfileNameList.some((uploadedFile) => uploadedFile.includes(fileName))
+      );
       fileNameList = [...fileNameList, ...uploadedfileNameList];
     }
 

--- a/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.hooks.ts
+++ b/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.hooks.ts
@@ -11,15 +11,17 @@ export const useNotieEditAction = (id: number, noticeData: PutNoticeReq) => {
   const [fileData, setFileData] = useNoticeFileStore();
 
   const handleNoticeEditButtonClick = async () => {
-    let fileNames: string[] = noticeData.fileNames ? noticeData.fileNames : [];
+    let fileNameList: Array<string> = noticeData.fileNameList
+      ? noticeData.fileNameList
+      : [];
 
     if (fileData && fileData.length > 0) {
-      const uploadedFileNames = await uploadFile(fileData);
-      fileNames = [...fileNames, ...uploadedFileNames];
+      const uploadedfileNameList = await uploadFile(fileData);
+      fileNameList = [...fileNameList, ...uploadedfileNameList];
     }
 
     editNoticeMutate(
-      { ...noticeData, fileNames },
+      { ...noticeData, fileNameList },
       {
         onSuccess: () => {
           setFileData([]);

--- a/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.hooks.ts
+++ b/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.hooks.ts
@@ -11,17 +11,18 @@ export const useNotieEditAction = (id: number, noticeData: PutNoticeReq) => {
   const [fileData, setFileData] = useNoticeFileStore();
 
   const handleNoticeEditButtonClick = async () => {
-    let fileName = noticeData.fileName || '';
+    let fileNames: string[] = noticeData.fileNames ? noticeData.fileNames : [];
 
-    if (fileData) {
-      fileName = await uploadFile(fileData);
+    if (fileData && fileData.length > 0) {
+      const uploadedFileNames = await uploadFile(fileData);
+      fileNames = [...fileNames, ...uploadedFileNames];
     }
 
     editNoticeMutate(
-      { ...noticeData, fileName },
+      { ...noticeData, fileNames },
       {
         onSuccess: () => {
-          setFileData(null);
+          setFileData([]);
         },
       }
     );

--- a/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.tsx
+++ b/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.tsx
@@ -22,7 +22,7 @@ const NoticeEdit = ({ id }: Props) => {
   const [noticeData, setNoticeData] = useState({
     title: noticeDetailData?.title ?? '',
     content: noticeDetailData?.content ?? '',
-    fileNames: noticeDetailData?.fileNames ?? [],
+    fileList: noticeDetailData?.fileList ?? [],
   });
 
   const { handleNoticeEditButtonClick } = useNotieEditAction(id, noticeData);
@@ -48,7 +48,7 @@ const NoticeEdit = ({ id }: Props) => {
           if (file) {
             setNoticeData((prevData) => ({
               ...prevData,
-              fileNames: [...prevData.fileNames, file.name],
+              fileList: [...prevData.fileList, { fileName: file.name, downloadUrl: '' }],
             }));
           }
         }}
@@ -59,7 +59,7 @@ const NoticeEdit = ({ id }: Props) => {
   const handleDeleteNoticeFile = (fileNameToDelete: string) => {
     setNoticeData((prevData) => ({
       ...prevData,
-      fileNames: prevData.fileNames.filter((fileName) => fileName !== fileNameToDelete),
+      fileList: prevData.fileList.filter((file) => file.fileName !== fileNameToDelete),
     }));
   };
 
@@ -96,19 +96,19 @@ const NoticeEdit = ({ id }: Props) => {
           placeholder="내용을 작성해주세요."
           rows={1}
         />
-        {noticeData.fileNames.length > 0 && (
+        {noticeData.fileList && (
           <Column gap={12}>
-            {noticeData.fileNames.map((fileName, index) => (
+            {noticeData.fileList.map((file, index) => (
               <Row alignItems="center" gap={12} key={index}>
                 <StyledNoticeFile>
                   <Row alignItems="center" gap={10}>
                     <IconClip width={19} height={12} />
                     <Text fontType="p3" color={color.gray750}>
-                      {formatFileName(fileName)}
+                      {formatFileName(file.fileName)}
                     </Text>
                   </Row>
                 </StyledNoticeFile>
-                <DeleteButton onClick={() => handleDeleteNoticeFile(fileName)}>
+                <DeleteButton onClick={() => handleDeleteNoticeFile(file.fileName)}>
                   <Text fontType="caption" color={color.red}>
                     [삭제]
                   </Text>

--- a/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.tsx
+++ b/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.tsx
@@ -22,10 +22,13 @@ const NoticeEdit = ({ id }: Props) => {
   const [noticeData, setNoticeData] = useState({
     title: noticeDetailData?.title ?? '',
     content: noticeDetailData?.content ?? '',
-    fileList: noticeDetailData?.fileList ?? [],
+    fileList: noticeDetailData?.fileList?.map((file) => file.fileName) ?? [],
   });
 
-  const { handleNoticeEditButtonClick } = useNotieEditAction(id, noticeData);
+  const { handleNoticeEditButtonClick } = useNotieEditAction(id, {
+    ...noticeData,
+    fileNameList: noticeData.fileList.map((file) => file),
+  });
   const overlay = useOverlay();
 
   const handleNoticeDataChange: ChangeEventHandler<
@@ -33,7 +36,7 @@ const NoticeEdit = ({ id }: Props) => {
   > = (e) => {
     const { name, value } = e.target;
     setNoticeData({ ...noticeData, [name]: value });
-
+    console.log(noticeData);
     resizeTextarea(contentTextareaRef);
   };
 
@@ -48,7 +51,7 @@ const NoticeEdit = ({ id }: Props) => {
           if (file) {
             setNoticeData((prevData) => ({
               ...prevData,
-              fileList: [...prevData.fileList, { fileName: file.name, downloadUrl: '' }],
+              fileList: [...prevData.fileList, file.name],
             }));
           }
         }}
@@ -59,7 +62,7 @@ const NoticeEdit = ({ id }: Props) => {
   const handleDeleteNoticeFile = (fileNameToDelete: string) => {
     setNoticeData((prevData) => ({
       ...prevData,
-      fileList: prevData.fileList.filter((file) => file.fileName !== fileNameToDelete),
+      fileList: prevData.fileList.filter((file) => file !== fileNameToDelete),
     }));
   };
 
@@ -77,9 +80,10 @@ const NoticeEdit = ({ id }: Props) => {
             <Button
               size="SMALL"
               icon="CLIP_ICON"
-              styleType="SECONDARY"
+              styleType={noticeData.fileList.length >= 3 ? 'DISABLED' : 'SECONDARY'}
               width={124}
               onClick={handleNoticeFileModalButtonClick}
+              disabled={noticeData.fileList.length >= 3}
             >
               파일 첨부
             </Button>
@@ -104,11 +108,11 @@ const NoticeEdit = ({ id }: Props) => {
                   <Row alignItems="center" gap={10}>
                     <IconClip width={19} height={12} />
                     <Text fontType="p3" color={color.gray750}>
-                      {formatFileName(file.fileName)}
+                      {formatFileName(file)}
                     </Text>
                   </Row>
                 </StyledNoticeFile>
-                <DeleteButton onClick={() => handleDeleteNoticeFile(file.fileName)}>
+                <DeleteButton onClick={() => handleDeleteNoticeFile(file)}>
                   <Text fontType="caption" color={color.red}>
                     [삭제]
                   </Text>

--- a/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.tsx
+++ b/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.tsx
@@ -10,6 +10,7 @@ import { useNotieEditAction } from './NoticeEdit.hooks';
 import NoticeUploadModal from '../NoticeUploadModal/NoticeUploadModal';
 import { useOverlay } from '@toss/use-overlay';
 import { IconClip } from '@maru/icon';
+import { useNoticeFileStore } from '@/store/notice/noticeFile';
 
 interface Props {
   id: number;
@@ -17,6 +18,7 @@ interface Props {
 
 const NoticeEdit = ({ id }: Props) => {
   const { data: noticeDetailData } = useNoticeDetailQuery(id);
+  const [fileData, setFileData] = useNoticeFileStore();
 
   const contentTextareaRef = useRef<HTMLTextAreaElement>(null);
   const [noticeData, setNoticeData] = useState({
@@ -64,6 +66,7 @@ const NoticeEdit = ({ id }: Props) => {
       ...prevData,
       fileList: prevData.fileList.filter((file) => file !== fileNameToDelete),
     }));
+    setFileData(fileData?.filter((file) => file.name !== fileNameToDelete) ?? []);
   };
 
   return (

--- a/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.tsx
+++ b/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.tsx
@@ -22,7 +22,7 @@ const NoticeEdit = ({ id }: Props) => {
   const [noticeData, setNoticeData] = useState({
     title: noticeDetailData?.title ?? '',
     content: noticeDetailData?.content ?? '',
-    fileName: noticeDetailData?.fileName ?? '',
+    fileNames: noticeDetailData?.fileNames ?? [],
   });
 
   const { handleNoticeEditButtonClick } = useNotieEditAction(id, noticeData);
@@ -46,11 +46,21 @@ const NoticeEdit = ({ id }: Props) => {
         onClose={close}
         onFileAttach={(file) => {
           if (file) {
-            setNoticeData({ ...noticeData, fileName: file.name });
+            setNoticeData((prevData) => ({
+              ...prevData,
+              fileNames: [...prevData.fileNames, file.name],
+            }));
           }
         }}
       />
     ));
+  };
+
+  const handleDeleteNoticeFile = (fileNameToDelete: string) => {
+    setNoticeData((prevData) => ({
+      ...prevData,
+      fileNames: prevData.fileNames.filter((fileName) => fileName !== fileNameToDelete),
+    }));
   };
 
   return (
@@ -86,15 +96,26 @@ const NoticeEdit = ({ id }: Props) => {
           placeholder="내용을 작성해주세요."
           rows={1}
         />
-        {noticeData.fileName && (
-          <StyledNoticeFile>
-            <Row alignItems="center" gap={10}>
-              <IconClip width={19} height={12} />
-              <Text fontType="p3" color={color.gray750}>
-                {formatFileName(noticeData.fileName || '')}
-              </Text>
-            </Row>
-          </StyledNoticeFile>
+        {noticeData.fileNames.length > 0 && (
+          <Column gap={12}>
+            {noticeData.fileNames.map((fileName, index) => (
+              <Row alignItems="center" gap={12} key={index}>
+                <StyledNoticeFile>
+                  <Row alignItems="center" gap={10}>
+                    <IconClip width={19} height={12} />
+                    <Text fontType="p3" color={color.gray750}>
+                      {formatFileName(fileName)}
+                    </Text>
+                  </Row>
+                </StyledNoticeFile>
+                <DeleteButton onClick={() => handleDeleteNoticeFile(fileName)}>
+                  <Text fontType="caption" color={color.red}>
+                    [삭제]
+                  </Text>
+                </DeleteButton>
+              </Row>
+            ))}
+          </Column>
         )}
       </Column>
     </StyledNoticeEdit>
@@ -154,4 +175,9 @@ const StyledNoticeFile = styled.div`
   &:hover {
     background-color: ${color.gray300};
   }
+`;
+
+const DeleteButton = styled.div`
+  ${flex({ justifyContent: 'space-between', alignItems: 'center' })};
+  cursor: pointer;
 `;

--- a/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.tsx
+++ b/apps/admin/src/components/notice/NoticeEdit/NoticeEdit.tsx
@@ -36,7 +36,7 @@ const NoticeEdit = ({ id }: Props) => {
   > = (e) => {
     const { name, value } = e.target;
     setNoticeData({ ...noticeData, [name]: value });
-    console.log(noticeData);
+
     resizeTextarea(contentTextareaRef);
   };
 

--- a/apps/admin/src/components/notice/NoticePost/NoticePost.hooks.ts
+++ b/apps/admin/src/components/notice/NoticePost/NoticePost.hooks.ts
@@ -11,15 +11,17 @@ export const useNoticePostAction = (noticeData: PostNoticeReq) => {
   const [fileData, setFileData] = useNoticeFileStore();
 
   const handleNoticePostButtonClick = async () => {
-    let fileNames: string[] = noticeData.fileNames ? noticeData.fileNames : [];
+    let fileNameList: Array<string> = noticeData.fileNameList
+      ? noticeData.fileNameList
+      : [];
 
     if (fileData && fileData.length > 0) {
-      const uploadedFileNames = await uploadFile(fileData);
-      fileNames = [...fileNames, ...uploadedFileNames];
+      const uploadedfileNameList = await uploadFile(fileData);
+      fileNameList = [...fileNameList, ...uploadedfileNameList];
     }
 
     postNoticeMutate(
-      { ...noticeData, fileNames },
+      { ...noticeData, fileNameList },
       {
         onSuccess: () => {
           setFileData([]);

--- a/apps/admin/src/components/notice/NoticePost/NoticePost.hooks.ts
+++ b/apps/admin/src/components/notice/NoticePost/NoticePost.hooks.ts
@@ -17,6 +17,10 @@ export const useNoticePostAction = (noticeData: PostNoticeReq) => {
 
     if (fileData && fileData.length > 0) {
       const uploadedfileNameList = await uploadFile(fileData);
+      fileNameList = fileNameList.filter(
+        (fileName) =>
+          !uploadedfileNameList.some((uploadedFile) => uploadedFile.includes(fileName))
+      );
       fileNameList = [...fileNameList, ...uploadedfileNameList];
     }
 

--- a/apps/admin/src/components/notice/NoticePost/NoticePost.hooks.ts
+++ b/apps/admin/src/components/notice/NoticePost/NoticePost.hooks.ts
@@ -11,17 +11,18 @@ export const useNoticePostAction = (noticeData: PostNoticeReq) => {
   const [fileData, setFileData] = useNoticeFileStore();
 
   const handleNoticePostButtonClick = async () => {
-    let fileName = null;
+    let fileNames: string[] = noticeData.fileNames ? noticeData.fileNames : [];
 
-    if (fileData) {
-      fileName = await uploadFile(fileData);
+    if (fileData && fileData.length > 0) {
+      const uploadedFileNames = await uploadFile(fileData);
+      fileNames = [...fileNames, ...uploadedFileNames];
     }
 
     postNoticeMutate(
-      { ...noticeData, fileName },
+      { ...noticeData, fileNames },
       {
         onSuccess: () => {
-          setFileData(null);
+          setFileData([]);
         },
       }
     );

--- a/apps/admin/src/components/notice/NoticePost/NoticePost.tsx
+++ b/apps/admin/src/components/notice/NoticePost/NoticePost.tsx
@@ -1,6 +1,6 @@
 import { resizeTextarea } from '@/utils';
 import { color, font } from '@maru/design-token';
-import { Button, Column, Row } from '@maru/ui';
+import { Button, Column, Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import type { ChangeEventHandler } from 'react';
 import { useRef, useState } from 'react';
@@ -17,7 +17,7 @@ const NoticePost = () => {
     title: '',
     content: '',
   });
-  const [fileName, setFileName] = useState<string | null>(null);
+  const [fileNames, setFileNames] = useState<string[]>([]);
 
   const { handleNoticePostButtonClick } = useNoticePostAction(noticeData);
 
@@ -35,9 +35,19 @@ const NoticePost = () => {
       <NoticeUploadModal
         isOpen={isOpen}
         onClose={close}
-        onFileAttach={(file) => setFileName(file?.name || null)}
+        onFileAttach={(file) => {
+          if (file) {
+            setFileNames((prev) => [...prev, file.name]);
+          }
+        }}
       />
     ));
+  };
+
+  const handleDeleteNoticeFile = (fileNameToDelete: string) => {
+    setFileNames((prevFileNames) =>
+      prevFileNames.filter((name) => name !== fileNameToDelete)
+    );
   };
 
   return (
@@ -54,9 +64,10 @@ const NoticePost = () => {
             <Button
               size="SMALL"
               icon="CLIP_ICON"
-              styleType="SECONDARY"
+              styleType={fileNames.length >= 3 ? 'DISABLED' : 'SECONDARY'}
               width={124}
               onClick={handleNoticeFileModalButtonClick}
+              disabled={fileNames.length >= 3}
             >
               파일 첨부
             </Button>
@@ -73,13 +84,24 @@ const NoticePost = () => {
           placeholder="내용을 작성해주세요."
           rows={1}
         />
-        {fileName && (
-          <StyledNoticeFile>
-            <Row alignItems="center" gap={10}>
-              <IconClip width={19} height={12} />
-              {fileName}
-            </Row>
-          </StyledNoticeFile>
+        {fileNames.length > 0 && (
+          <Column gap={12}>
+            {fileNames.map((fileName, index) => (
+              <Row alignItems="center" gap={12} key={index}>
+                <StyledNoticeFile>
+                  <Row alignItems="center" gap={10}>
+                    <IconClip width={19} height={12} />
+                    {fileName}
+                  </Row>
+                </StyledNoticeFile>
+                <DeleteButton onClick={() => handleDeleteNoticeFile(fileName)}>
+                  <Text fontType="caption" color={color.red}>
+                    [삭제]
+                  </Text>
+                </DeleteButton>
+              </Row>
+            ))}
+          </Column>
         )}
       </Column>
     </StyledNoticePost>
@@ -139,4 +161,9 @@ const StyledNoticeFile = styled.div`
   &:hover {
     background-color: ${color.gray300};
   }
+`;
+
+const DeleteButton = styled.div`
+  ${flex({ justifyContent: 'space-between', alignItems: 'center' })};
+  cursor: pointer;
 `;

--- a/apps/admin/src/components/notice/NoticePost/NoticePost.tsx
+++ b/apps/admin/src/components/notice/NoticePost/NoticePost.tsx
@@ -17,7 +17,7 @@ const NoticePost = () => {
     title: '',
     content: '',
   });
-  const [fileNames, setFileNames] = useState<string[]>([]);
+  const [fileNameList, setfileNameList] = useState<Array<string>>([]);
 
   const { handleNoticePostButtonClick } = useNoticePostAction(noticeData);
 
@@ -37,7 +37,7 @@ const NoticePost = () => {
         onClose={close}
         onFileAttach={(file) => {
           if (file) {
-            setFileNames((prev) => [...prev, file.name]);
+            setfileNameList((prev) => [...prev, file.name]);
           }
         }}
       />
@@ -45,8 +45,8 @@ const NoticePost = () => {
   };
 
   const handleDeleteNoticeFile = (fileNameToDelete: string) => {
-    setFileNames((prevFileNames) =>
-      prevFileNames.filter((name) => name !== fileNameToDelete)
+    setfileNameList((prevfileNameList) =>
+      prevfileNameList.filter((name) => name !== fileNameToDelete)
     );
   };
 
@@ -64,10 +64,10 @@ const NoticePost = () => {
             <Button
               size="SMALL"
               icon="CLIP_ICON"
-              styleType={fileNames.length >= 3 ? 'DISABLED' : 'SECONDARY'}
+              styleType={fileNameList.length >= 3 ? 'DISABLED' : 'SECONDARY'}
               width={124}
               onClick={handleNoticeFileModalButtonClick}
-              disabled={fileNames.length >= 3}
+              disabled={fileNameList.length >= 3}
             >
               파일 첨부
             </Button>
@@ -84,9 +84,9 @@ const NoticePost = () => {
           placeholder="내용을 작성해주세요."
           rows={1}
         />
-        {fileNames.length > 0 && (
+        {fileNameList.length > 0 && (
           <Column gap={12}>
-            {fileNames.map((fileName, index) => (
+            {fileNameList.map((fileName, index) => (
               <Row alignItems="center" gap={12} key={index}>
                 <StyledNoticeFile>
                   <Row alignItems="center" gap={10}>

--- a/apps/admin/src/components/notice/NoticePost/NoticePost.tsx
+++ b/apps/admin/src/components/notice/NoticePost/NoticePost.tsx
@@ -9,10 +9,13 @@ import { useNoticePostAction } from './NoticePost.hooks';
 import { useOverlay } from '@toss/use-overlay';
 import NoticeUploadModal from '../NoticeUploadModal/NoticeUploadModal';
 import { IconClip } from '@maru/icon';
+import { useNoticeFileStore } from '@/store/notice/noticeFile';
 
 const NoticePost = () => {
   const overlay = useOverlay();
   const contentTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const [fileData, setFileData] = useNoticeFileStore();
+
   const [noticeData, setNoticeData] = useState<{
     title: string;
     content: string;
@@ -56,6 +59,7 @@ const NoticePost = () => {
       ...prevData,
       fileNameList: prevData.fileNameList.filter((file) => file !== fileNameToDelete),
     }));
+    setFileData(fileData?.filter((file) => file.name !== fileNameToDelete) ?? []);
   };
 
   return (

--- a/apps/admin/src/components/notice/NoticePost/NoticePost.tsx
+++ b/apps/admin/src/components/notice/NoticePost/NoticePost.tsx
@@ -13,11 +13,15 @@ import { IconClip } from '@maru/icon';
 const NoticePost = () => {
   const overlay = useOverlay();
   const contentTextareaRef = useRef<HTMLTextAreaElement>(null);
-  const [noticeData, setNoticeData] = useState({
+  const [noticeData, setNoticeData] = useState<{
+    title: string;
+    content: string;
+    fileNameList: string[];
+  }>({
     title: '',
     content: '',
+    fileNameList: [],
   });
-  const [fileNameList, setfileNameList] = useState<Array<string>>([]);
 
   const { handleNoticePostButtonClick } = useNoticePostAction(noticeData);
 
@@ -37,7 +41,10 @@ const NoticePost = () => {
         onClose={close}
         onFileAttach={(file) => {
           if (file) {
-            setfileNameList((prev) => [...prev, file.name]);
+            setNoticeData((prevData) => ({
+              ...prevData,
+              fileNameList: [...prevData.fileNameList, file.name],
+            }));
           }
         }}
       />
@@ -45,9 +52,10 @@ const NoticePost = () => {
   };
 
   const handleDeleteNoticeFile = (fileNameToDelete: string) => {
-    setfileNameList((prevfileNameList) =>
-      prevfileNameList.filter((name) => name !== fileNameToDelete)
-    );
+    setNoticeData((prevData) => ({
+      ...prevData,
+      fileNameList: prevData.fileNameList.filter((file) => file !== fileNameToDelete),
+    }));
   };
 
   return (
@@ -64,10 +72,10 @@ const NoticePost = () => {
             <Button
               size="SMALL"
               icon="CLIP_ICON"
-              styleType={fileNameList.length >= 3 ? 'DISABLED' : 'SECONDARY'}
+              styleType={noticeData.fileNameList.length >= 3 ? 'DISABLED' : 'SECONDARY'}
               width={124}
               onClick={handleNoticeFileModalButtonClick}
-              disabled={fileNameList.length >= 3}
+              disabled={noticeData.fileNameList.length >= 3}
             >
               파일 첨부
             </Button>
@@ -84,17 +92,17 @@ const NoticePost = () => {
           placeholder="내용을 작성해주세요."
           rows={1}
         />
-        {fileNameList.length > 0 && (
+        {noticeData.fileNameList.length > 0 && (
           <Column gap={12}>
-            {fileNameList.map((fileName, index) => (
+            {noticeData.fileNameList.map((file, index) => (
               <Row alignItems="center" gap={12} key={index}>
                 <StyledNoticeFile>
                   <Row alignItems="center" gap={10}>
                     <IconClip width={19} height={12} />
-                    {fileName}
+                    {file}
                   </Row>
                 </StyledNoticeFile>
-                <DeleteButton onClick={() => handleDeleteNoticeFile(fileName)}>
+                <DeleteButton onClick={() => handleDeleteNoticeFile(file)}>
                   <Text fontType="caption" color={color.red}>
                     [삭제]
                   </Text>

--- a/apps/admin/src/components/notice/NoticeUploadModal/NoticeUploadModal.tsx
+++ b/apps/admin/src/components/notice/NoticeUploadModal/NoticeUploadModal.tsx
@@ -1,10 +1,10 @@
-import { useNoticeFileStore } from '@/store/notice/noticeFile';
+import { useRef, useEffect } from 'react';
+import { useNoticeFileStore, useVisibleNoticeFileStore } from '@/store/notice/noticeFile';
 import { color } from '@maru/design-token';
 import { IconClose } from '@maru/icon';
 import { Button, Column, Row, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
 import type { ChangeEventHandler } from 'react';
-import { useRef } from 'react';
 import styled from 'styled-components';
 import NoticeUploader from './NoticeUploader/NoticeUploader';
 
@@ -16,7 +16,14 @@ interface Props {
 
 const NoticeUploadModal = ({ isOpen, onClose, onFileAttach }: Props) => {
   const [fileData, setFileData] = useNoticeFileStore();
+  const [visibleFile, setVisibleFile] = useVisibleNoticeFileStore();
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setVisibleFile(null);
+    }
+  }, [isOpen, setVisibleFile]);
 
   const handleUploadFileButtonClick = () => {
     fileInputRef.current?.click();
@@ -32,19 +39,20 @@ const NoticeUploadModal = ({ isOpen, onClose, onFileAttach }: Props) => {
 
     if (!files || files.length === 0) return;
     const selectedFile = files[0];
-    setFileData(selectedFile);
-    onFileAttach(selectedFile);
+    setVisibleFile(selectedFile);
   };
 
   const removeFileAndCloseModal = () => {
-    setFileData(null);
+    setVisibleFile(null);
     removeFileInputValue();
     onFileAttach(null);
     onClose();
   };
 
   const handleAttachFile = () => {
-    if (fileData) {
+    if (visibleFile) {
+      onFileAttach(visibleFile);
+      setFileData(fileData ? [...fileData, visibleFile] : [visibleFile]);
       onClose();
     }
   };
@@ -72,6 +80,7 @@ const NoticeUploadModal = ({ isOpen, onClose, onFileAttach }: Props) => {
         <NoticeUploader
           removeFileInputValue={removeFileAndCloseModal}
           handleUploadFileButtonClick={handleUploadFileButtonClick}
+          isOpen={isOpen}
         />
         <Row gap={16} style={{ alignSelf: 'flex-end' }}>
           <Button size="SMALL" styleType="SECONDARY" onClick={removeFileAndCloseModal}>
@@ -79,7 +88,7 @@ const NoticeUploadModal = ({ isOpen, onClose, onFileAttach }: Props) => {
           </Button>
           <Button
             size="SMALL"
-            styleType={fileData ? 'PRIMARY' : 'DISABLED'}
+            styleType={visibleFile ? 'PRIMARY' : 'DISABLED'}
             onClick={handleAttachFile}
           >
             첨부하기

--- a/apps/admin/src/components/notice/NoticeUploadModal/NoticeUploader/NoticeUploader.tsx
+++ b/apps/admin/src/components/notice/NoticeUploadModal/NoticeUploader/NoticeUploader.tsx
@@ -1,23 +1,34 @@
-import { useNoticeFileStore } from '@/store/notice/noticeFile';
+import { useVisibleNoticeFileStore } from '@/store/notice/noticeFile';
 import { color } from '@maru/design-token';
 import { IconClose } from '@maru/icon';
 import { Button, Column, Text } from '@maru/ui';
 import { flex } from '@maru/utils';
-import { useState, type DragEvent } from 'react';
+import { useEffect, useState, type DragEvent } from 'react';
 import styled from 'styled-components';
 
 interface Props {
+  isOpen: boolean;
   removeFileInputValue: () => void;
   handleUploadFileButtonClick: () => void;
 }
 
-const NoticeUploader = ({ removeFileInputValue, handleUploadFileButtonClick }: Props) => {
-  const [fileData, setFileData] = useNoticeFileStore();
+const NoticeUploader = ({
+  isOpen,
+  removeFileInputValue,
+  handleUploadFileButtonClick,
+}: Props) => {
+  const [visibleFile, setVisibleFile] = useVisibleNoticeFileStore();
   const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setVisibleFile(null);
+    }
+  }, [isOpen, setVisibleFile]);
 
   const handleUploadCancelButtonClick = () => {
     removeFileInputValue();
-    setFileData(null);
+    setVisibleFile(null);
   };
 
   const onDragEnter = (e: DragEvent<HTMLDivElement>) => {
@@ -43,7 +54,12 @@ const NoticeUploader = ({ removeFileInputValue, handleUploadFileButtonClick }: P
   const onDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    setFileData(e.dataTransfer.files[0]);
+
+    const droppedFile = e.dataTransfer.files[0];
+    if (droppedFile) {
+      setVisibleFile(droppedFile);
+      setIsDragging(false);
+    }
   };
 
   return (
@@ -55,10 +71,10 @@ const NoticeUploader = ({ removeFileInputValue, handleUploadFileButtonClick }: P
       $isDragging={isDragging}
     >
       <Column gap={12} alignItems="center">
-        {fileData ? (
+        {visibleFile ? (
           <FileNameBox>
             <Text fontType="p2" color={color.gray900}>
-              {fileData.name}
+              {visibleFile.name}
             </Text>
             <IconClose
               width={18}

--- a/apps/admin/src/services/notice/api.ts
+++ b/apps/admin/src/services/notice/api.ts
@@ -19,17 +19,22 @@ export const getNoticeDetail = async (id: number) => {
   return data;
 };
 
-export const downloadFile = async (fileUrl: string) => {
-  const response = await maru.get(fileUrl, {
-    responseType: 'blob',
-  });
-  return response.data;
+export const downloadFiles = async (fileUrls: string[]) => {
+  const downloadPromises = fileUrls.map((fileUrl) =>
+    maru.get(fileUrl, {
+      responseType: 'blob',
+    })
+  );
+
+  const responses = await Promise.all(downloadPromises);
+
+  return responses.map((response) => response.data);
 };
 
-export const postNotice = async ({ title, content, fileName }: PostNoticeReq) => {
+export const postNotice = async ({ title, content, fileNames }: PostNoticeReq) => {
   const { data } = await maru.post(
     '/notice',
-    { title, content, fileName },
+    { title, content, fileNames },
     authorization()
   );
   return data;
@@ -37,11 +42,11 @@ export const postNotice = async ({ title, content, fileName }: PostNoticeReq) =>
 
 export const putEditNotice = async (
   id: number,
-  { title, content, fileName }: PutNoticeReq
+  { title, content, fileNames }: PutNoticeReq
 ) => {
   const { data } = await maru.put(
     `/notice/${id}`,
-    { title, content, fileName },
+    { title, content, fileNames },
     authorization()
   );
   return { data };
@@ -53,9 +58,9 @@ export const deleteNotice = async (id: number) => {
 };
 
 export const postNoticePresignedUrl = async (
-  fileName: string
+  fileNames: string[]
 ): Promise<PresignedDatReq> => {
-  const response = await maru.post(`/notice/file`, { fileName }, authorization());
+  const response = await maru.post(`/notice/file`, { fileNames }, authorization());
 
   const { url, fields, fileName: returnedFileName } = response.data.data;
 
@@ -65,15 +70,17 @@ export const postNoticePresignedUrl = async (
     fileName: returnedFileName,
   } as PresignedDatReq;
 };
-
-export const putNoticeFileUrl = async (file: File, presignedData: PresignedDatReq) => {
+export const putNoticeFileUrl = async (files: File[], presignedData: PresignedDatReq) => {
   const { url } = presignedData;
 
-  const response = await axios.put(url.uploadUrl, file, {
-    headers: {
-      'Content-Type': file.type,
-    },
+  const uploadPromises = files.map((file, index) => {
+    return axios.put(url.uploadUrl[index], file, {
+      headers: {
+        'Content-Type': file.type,
+      },
+    });
   });
 
-  return response;
+  const responses = await Promise.all(uploadPromises);
+  return responses;
 };

--- a/apps/admin/src/services/notice/mutations.ts
+++ b/apps/admin/src/services/notice/mutations.ts
@@ -1,6 +1,6 @@
 import { ROUTES } from '@/constants/common/constant';
 import { useApiError } from '@/hooks';
-import type { PostNoticeReq, PutNoticeReq } from '@/types/notice/remote';
+import type { PostNoticeReq, PresignedDatReq, PutNoticeReq } from '@/types/notice/remote';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
@@ -72,15 +72,15 @@ export const useUploadFileWithPresignedUrl = () => {
   const fileData = useNoticeFileValueStore();
 
   const mutation = useMutation(
-    async (file: File[]) => {
+    async (files: File[]) => {
       if (!fileData) {
         throw new Error('파일이 선택되지 않았습니다.');
       }
 
-      const fileNames = fileData.map((file) => file.name);
-      const presignedData = await postNoticePresignedUrl(fileNames);
-      await putNoticeFileUrl(file, presignedData);
-      return presignedData.fileName;
+      const fileNameList = fileData.map((file) => file.name);
+      const presignedData: PresignedDatReq[] = await postNoticePresignedUrl(fileNameList);
+      await putNoticeFileUrl(files, presignedData);
+      return presignedData.map((data) => data.fileName);
     },
     {
       onError: handleError,

--- a/apps/admin/src/services/notice/mutations.ts
+++ b/apps/admin/src/services/notice/mutations.ts
@@ -72,12 +72,13 @@ export const useUploadFileWithPresignedUrl = () => {
   const fileData = useNoticeFileValueStore();
 
   const mutation = useMutation(
-    async (file: File) => {
+    async (file: File[]) => {
       if (!fileData) {
         throw new Error('파일이 선택되지 않았습니다.');
       }
 
-      const presignedData = await postNoticePresignedUrl(fileData.name);
+      const fileNames = fileData.map((file) => file.name);
+      const presignedData = await postNoticePresignedUrl(fileNames);
       await putNoticeFileUrl(file, presignedData);
       return presignedData.fileName;
     },

--- a/apps/admin/src/store/notice/noticeFile.ts
+++ b/apps/admin/src/store/notice/noticeFile.ts
@@ -1,9 +1,20 @@
 import { atom, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
-const noticeFileAtomState = atom<File | null>({
+const noticeFileAtomState = atom<File[] | null>({
   key: 'notice-file',
   default: null,
 });
+
+const visibleNoticeFileAtomState = atom<File | null>({
+  key: 'visible-notice-file',
+  default: null,
+});
+
+export const useVisibleNoticeFileStore = () => useRecoilState(visibleNoticeFileAtomState);
+export const useVisibleNoticeFileValueStore = () =>
+  useRecoilState(visibleNoticeFileAtomState);
+export const useSetVisibleNoticeFileStore = () =>
+  useRecoilState(visibleNoticeFileAtomState);
 
 export const useNoticeFileStore = () => useRecoilState(noticeFileAtomState);
 export const useNoticeFileValueStore = () => useRecoilValue(noticeFileAtomState);

--- a/apps/admin/src/types/notice/client.ts
+++ b/apps/admin/src/types/notice/client.ts
@@ -7,7 +7,9 @@ export interface Notice {
 export interface NoticeDetail {
   title: string;
   content: string;
-  fileUrls?: string[];
-  fileNames?: string[];
+  fileList?: Array<{
+    downloadUrl: string;
+    fileName: string;
+  }>;
   createdAt: string;
 }

--- a/apps/admin/src/types/notice/client.ts
+++ b/apps/admin/src/types/notice/client.ts
@@ -7,7 +7,7 @@ export interface Notice {
 export interface NoticeDetail {
   title: string;
   content: string;
-  fileUrl?: string;
-  fileName?: string;
+  fileUrls?: string[];
+  fileNames?: string[];
   createdAt: string;
 }

--- a/apps/admin/src/types/notice/remote.ts
+++ b/apps/admin/src/types/notice/remote.ts
@@ -11,22 +11,22 @@ export interface GetNoticeDetailRes {
 export interface PostNoticeReq {
   title: string;
   content: string;
-  fileName?: string | null;
+  fileNames?: string[] | null;
 }
 
 export interface PutNoticeReq {
   title: string;
   content: string;
-  fileName?: string | null;
+  fileNames?: string[] | null;
 }
 
 export interface PresignedDatReq {
   url: {
-    uploadUrl: string;
-    downloadUrl?: string | null;
+    uploadUrl: string[];
+    downloadUrl?: string[] | null;
   };
   fields: {
     [key: string]: string | Blob;
   };
-  fileName: string;
+  fileName: string[];
 }

--- a/apps/admin/src/types/notice/remote.ts
+++ b/apps/admin/src/types/notice/remote.ts
@@ -11,22 +11,22 @@ export interface GetNoticeDetailRes {
 export interface PostNoticeReq {
   title: string;
   content: string;
-  fileNames?: string[] | null;
+  fileNameList?: Array<string> | null;
 }
 
 export interface PutNoticeReq {
   title: string;
   content: string;
-  fileNames?: string[] | null;
+  fileNameList?: Array<string> | null;
 }
 
 export interface PresignedDatReq {
   url: {
-    uploadUrl: string[];
-    downloadUrl?: string[] | null;
+    uploadUrl: string;
+    downloadUrl?: string | null;
   };
   fields: {
     [key: string]: string | Blob;
   };
-  fileName: string[];
+  fileName: string;
 }

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,28 +1,29 @@
 {
-    "compilerOptions": {
-        "target": "es5",
-        "lib": ["dom", "dom.iterable", "esnext"],
-        "allowJs": true,
-        "skipLibCheck": true,
-        "strict": true,
-        "forceConsistentCasingInFileNames": true,
-        "noEmit": true,
-        "esModuleInterop": true,
-        "module": "esnext",
-        "moduleResolution": "node",
-        "resolveJsonModule": true,
-        "isolatedModules": true,
-        "jsx": "preserve",
-        "incremental": true,
-        "plugins": [
-            {
-                "name": "next"
-            }
-        ],
-        "paths": {
-            "@/*": ["./src/*"]
-        }
-    },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-    "exclude": ["node_modules"]
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "downlevelIteration": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/apps/user/src/types/notice/client.ts
+++ b/apps/user/src/types/notice/client.ts
@@ -7,7 +7,9 @@ export interface Notice {
 export interface NoticeDetail {
   title: string;
   content: string;
-  fileUrl?: string;
-  fileName?: string;
+  fileList?: Array<{
+    downloadUrl: string;
+    fileName: string;
+  }>;
   createdAt: string;
 }

--- a/packages/ui/src/Flex/Row.tsx
+++ b/packages/ui/src/Flex/Row.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { styled } from 'styled-components';
 import type { FlexProps } from './Flex.type';
 


### PR DESCRIPTION
## 📄 Summary

> 공지사항 파일 수의 제한이 3개로 늘어나며 그에 맞게 수정했습니다.

<br>

## 🔨 Tasks

- 공지사항 파일 첨부 시 삭제 기능 추가
- 파일이 3개 이상일 경우 버튼을 disabled
- hwp파일일 경우에는 보이지 않는 바로보기 기능 추가 

<br>

## 🙋🏻 More
