### PR TITLE
fix(user): 원서 반려시  지원자 정보로 돌아가도록 수정

### DIFF
--- a/apps/user/src/app/form/page.tsx
+++ b/apps/user/src/app/form/page.tsx
@@ -22,7 +22,7 @@ const FormPage = () => {
 
   useEffect(() => {
     if (formStatusData?.status === 'REJECTED') {
-      setFormStep('최종제출');
+      setFormStep('지원자정보');
     }
   }, [formStatusData, setFormStep]);
 


### PR DESCRIPTION
## 📄 Summary

> 원서를 최종 제출후 반려가 되면 다시 원서를 지원자 정보부터 입력할 수 있도록 수정해 달라는 요청이 들어와서 이를 수정했습니다.

<br>

## 🔨 Tasks

- 원서 상태가 REJECTED이면 지원자 정보 페이지부터 보이도록 수정했습니다.

<br>

## 🙋🏻 More
