### PR TITLE
fix(user): 파일이 올라가지 않았는데 최종 제출되는 문제 수정

### DIFF
--- a/apps/user/src/app/form/최종제출/최종제출.hooks.ts
+++ b/apps/user/src/app/form/최종제출/최종제출.hooks.ts
@@ -78,11 +78,11 @@ export const useExportFormAction = (
   return { handleExportForm };
 };
 
-export const useInput = () => {
+export const useInput = (openLoader: () => void, closeLoader: () => void) => {
   const setFormDocument = useSetFormDocumentStore();
   const { uploadFormDocumentMutate, isLoading } =
     useUploadFormDocumentMutation(setFormDocument);
-  const [isUploadSuccessful] = useState(false);
+  const [isUploadSuccessful, setIsUploadSuccessful] = useState(false);
 
   const handleFormDocumentChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     const { files } = e.target;
@@ -92,7 +92,19 @@ export const useInput = () => {
 
     setFormDocument((prev) => ({ ...prev, fileName: file.name }));
 
-    uploadFormDocumentMutate(file);
+    openLoader();
+
+    uploadFormDocumentMutate(file, {
+      onSuccess: () => {
+        setIsUploadSuccessful(true);
+        closeLoader();
+      },
+      onError: () => {
+        setIsUploadSuccessful(false);
+        closeLoader();
+        alert('파일 업로드에 실패했습니다. 다시 시도해주세요.');
+      },
+    });
   };
 
   return { handleFormDocumentChange, isUploadSuccessful, isLoading };

--- a/apps/user/src/app/form/최종제출/최종제출.tsx
+++ b/apps/user/src/app/form/최종제출/최종제출.tsx
@@ -30,7 +30,11 @@ const 최종제출 = () => {
     closePdfGeneratedLoader
   );
   const { handleSubmitFinalForm } = useSubmitFinalFormAction();
-  const { handleFormDocumentChange } = useInput();
+
+  const { handleFormDocumentChange, isUploadSuccessful } = useInput(
+    openPdfGeneratedLoader,
+    closePdfGeneratedLoader
+  );
 
   const openFinalFormConfirm = () => {
     overlay.open(({ isOpen, close }) => (
@@ -102,7 +106,9 @@ const 최종제출 = () => {
               onClick={openFinalFormConfirm}
               width="100%"
               size="LARGE"
-              styleType={!formDocument.fileName ? 'DISABLED' : 'PRIMARY'}
+              styleType={
+                !formDocument.fileName || !isUploadSuccessful ? 'DISABLED' : 'PRIMARY'
+              }
             >
               원서 최종 제출
             </Button>

--- a/apps/user/src/components/form/PdfUploadLoader/PdfUploadLoader.tsx
+++ b/apps/user/src/components/form/PdfUploadLoader/PdfUploadLoader.tsx
@@ -1,0 +1,51 @@
+import { color } from '@maru/design-token';
+import { Column, Loader, Text } from '@maru/ui';
+import { flex } from '@maru/utils';
+import { styled } from 'styled-components';
+
+interface Props {
+  isOpen: boolean;
+}
+
+const PdfGeneratedLoader = ({ isOpen }: Props) => {
+  return (
+    <BlurBackground $isOpen={isOpen}>
+      <StyledPdfGeneratedLoader>
+        <Column gap={8}>
+          <Text fontType="H2" color={color.gray900}>
+            pdf를 업로드하는 중입니다.
+          </Text>
+          <Text fontType="p3" color={color.gray600}>
+            여러분의 원서를 올리는 중입니다. 조금만 기다려주세요!
+          </Text>
+        </Column>
+        <Loader top="65%" />
+      </StyledPdfGeneratedLoader>
+    </BlurBackground>
+  );
+};
+
+export default PdfGeneratedLoader;
+
+const BlurBackground = styled.div<{ $isOpen: boolean }>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: ${(props) => (props.$isOpen ? 'flex' : 'none')};
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 1;
+`;
+
+const StyledPdfGeneratedLoader = styled.div`
+  position: relative;
+  ${flex({ flexDirection: 'column', alignItems: 'center' })};
+  gap: 48px;
+  padding: 36px;
+  height: 280px;
+  background-color: ${color.white};
+  border-radius: 16px;
+`;

--- a/apps/user/src/components/form/index.ts
+++ b/apps/user/src/components/form/index.ts
@@ -12,3 +12,4 @@ export { default as PdfGeneratedLoader } from './PdfGeneratedLoader/PdfGenerated
 export { default as ProfileUploader } from './ProfileUploader/ProfileUploader';
 export { default as ProgressSteps } from './ProgressSteps/ProgressSteps';
 export { default as CropImageModal } from './CropImageModal/CropImageModal';
+export { default as PdfUploadLoader } from './PdfUploadLoader/PdfUploadLoader';


### PR DESCRIPTION
## 📄 Summary

> 파일이 올라가지 않았는데 파일이 버튼이 disabled로 풀려서 사용자가 누르고 최종 제출을 하면 어드민에서 원서 pdf가 보이지 않는 문제가 있었는데 이를 올라가는 동안 로더가 실행이 되고, 성공하기 전까지는 계속해서 버튼이 disabled이도록 수정함. 또 실패시 최대 3번을 시도하고 실패하면 다시 pdf를 넣도록 요청하도록 수정함

<br>

## 🔨 Tasks

- 로더 컴포넌트 개발
- 성공 유무에 따른 조건 추가

<br>

## 🙋🏻 More
